### PR TITLE
ppfinjector#19: PPF3 space optimization

### DIFF
--- a/app/patchtester/src/patchtester.cpp
+++ b/app/patchtester/src/patchtester.cpp
@@ -2,6 +2,7 @@
 
 #include <ppfbase/logging/logging.h>
 
+#include <fstream>
 #include <iostream>
 
 int main()
@@ -11,18 +12,46 @@ int main()
    const std::filesystem::path testPatch(
       "C:\\dev\\ppfinjector\\app\\patchtester\\data\\SotN-Randomizer (1691056147921).ppf");
 
-   const auto patch = tdd::tk::rompatch::ppf::Parse(testPatch);
+   const std::filesystem::path testTarget(
+      "C:\\Games\\Castlevania-Symphony of the Night[U] [SLUS-00067]\\Castlevania - Symphony of the Night (USA) (Track 1).bin");
 
-   if (patch.has_value()) {
-      std::cout << "Success." << std::endl;
-      std::cout << "Validation data: "
-         << (patch->GetValidationData().data.empty() ? "not" : "")
-         << " present" << std::endl;
-      std::cout << "Patch entries: " << patch->GetFullPatch().size()
-         << std::endl;
+   const std::filesystem::path compactedPatch(
+      "C:\\dev\\ppfinjector\\app\\patchtester\\data\\compacted.ppf");
+
+   auto patch = tdd::tk::rompatch::ppf::Parse(testPatch);
+
+   if (!patch.has_value()) {
+      std::cout << "Failed to parse the patch" << std::endl;
+      return 1;
+   }
+
+   std::cout << "Success." << std::endl;
+   std::cout << "Validation data: "
+      << (patch->GetValidationData().data.empty() ? "not" : "")
+      << " present" << std::endl;
+   std::cout << "Patch entries: " << patch->GetFullPatch().size()
+      << std::endl;
+
+   //patch->Compact();
+   //std::cout << "After compact" << std::endl;
+   //std::cout << "Patch entries: " << patch->GetFullPatch().size()
+   //   << std::endl;
+
+   auto target = std::ifstream(testTarget, std::ios::binary);
+   if (!patch->Compact(target)) {
+      std::cout << "Unable to compact with fillers";
+      return 2;
+   }
+   std::cout << "After compact" << std::endl;
+   std::cout << "Patch entries: " << patch->GetFullPatch().size()
+      << std::endl;
+
+   if (patch->ToFile(compactedPatch)) {
+      std::cout << "Unable to write compacted PFF" << std::endl;
    }
    else {
-      std::cout << "Failed to parse the patch" << std::endl;
+      std::cout << "Compacted patch saved" << std::endl;
    }
+
    return 0;
 }

--- a/base/ppfbase/inc/ppfbase/stdext/iostream.h
+++ b/base/ppfbase/inc/ppfbase/stdext/iostream.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <iostream>
+
+namespace tdd::stdext {
+   
+   template <
+      typename T,
+      std::enable_if_t<std::is_trivial_v<std::remove_cvref_t<T>>, void*> = nullptr>
+   void Read(std::istream& is, T& value)
+   {
+      is.read(reinterpret_cast<char*>(&value), sizeof(T));
+   }
+
+   template <
+      typename ContainerT,
+      std::enable_if_t<!std::is_trivial_v<std::remove_cvref_t<ContainerT>>, void*> = nullptr>
+   void Read(std::istream& is, ContainerT& value)
+   {
+      is.read(
+         reinterpret_cast<char*>(value.data()),
+         sizeof(typename ContainerT::value_type) * value.size());
+   }
+
+   template <
+      typename T,
+      std::enable_if_t<std::is_trivial_v<std::remove_cvref_t<T>>, void*> = nullptr>
+   void Write(std::ostream& os, const T& value)
+   {
+      os.write(reinterpret_cast<const char*>(&value), sizeof(T));
+   }
+
+   template <
+      typename ContainerT,
+      std::enable_if_t<!std::is_trivial_v<std::remove_cvref_t<ContainerT>>, void*> = nullptr>
+   void Write(std::ostream& os, const ContainerT& value)
+   {
+      os.write(
+         reinterpret_cast<const char*>(value.data()),
+         sizeof(typename ContainerT::value_type) * value.size());
+   }
+
+}

--- a/base/ppfbase/inc/ppfbase/stdext/poor_mans_expected.h
+++ b/base/ppfbase/inc/ppfbase/stdext/poor_mans_expected.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <ppfbase/stdext/system_error.h>
+#include <ppfbase/preprocessor_utils.h>
+#include <ppfbase/diagnostics/assert.h>
+
+#include <variant>
+
+namespace tdd::stdext {
+
+   template <typename T>
+   class [[nodiscard]] pm_expected
+   {
+   public:
+      template <
+         typename U = T,
+         std::enable_if_t<std::is_convertible_v<U, T>, void*> = nullptr>
+      pm_expected(U&& value)
+         noexcept(std::is_nothrow_convertible_v<decltype(m_data), U>)
+         : m_data(std::forward<U>(value))
+      {}
+
+      pm_expected(std::error_code ec) noexcept
+         : m_data(ec)
+      {}
+
+      [[nodiscard]] std::error_code error() const noexcept
+      {
+         if (has_value()) {
+            return {};
+         }
+         
+         return std::get<std::error_code>(m_data);
+      }
+
+      template <typename Fn>
+      [[nodiscard]] std::error_code handle_error(Fn&& fn) const
+      {
+         if (has_value()) {
+            return {};
+         }
+
+         return fn(error());
+      }
+
+      [[nodiscard]] bool has_value() const noexcept
+      {
+         return std::holds_alternative<T>(m_data);
+      }
+
+      [[nodiscard]] T const& value() const & noexcept
+      {
+         TDD_ASSERT(has_value());
+         return std::get<T>(m_data);
+      }
+      
+      [[nodiscard]] T& value() & noexcept
+      {
+         TDD_ASSERT(has_value());
+         return std::get<T>(m_data);
+      }
+
+      [[nodiscard]] T&& value() && noexcept
+      {
+         TDD_ASSERT(has_value());
+         return std::get<T>(std::move(m_data));
+      }
+
+   private:
+      std::variant<std::error_code, T> m_data;
+   };
+}

--- a/base/ppfbase/inc/ppfbase/stdext/system_error.h
+++ b/base/ppfbase/inc/ppfbase/stdext/system_error.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <system_error>
+
+namespace tdd::stdext {
+   inline [[nodiscard]] std::error_code make_win32_ec(uint32_t err) noexcept
+   {
+      return std::error_code(err, std::system_category());
+   }
+}

--- a/base/ppfbase/ppfbase.vcxproj
+++ b/base/ppfbase/ppfbase.vcxproj
@@ -24,8 +24,11 @@
     <ClInclude Include="inc\ppfbase\preprocessor_utils.h" />
     <ClInclude Include="inc\ppfbase\process\this_module.h" />
     <ClInclude Include="inc\ppfbase\process\this_process.h" />
+    <ClInclude Include="inc\ppfbase\stdext\iostream.h" />
+    <ClInclude Include="inc\ppfbase\stdext\poor_mans_expected.h" />
     <ClInclude Include="inc\ppfbase\stdext\stream_operator.h" />
     <ClInclude Include="inc\ppfbase\stdext\string.h" />
+    <ClInclude Include="inc\ppfbase\stdext\system_error.h" />
     <ClInclude Include="src\logging\basic_log.h" />
     <ClInclude Include="src\logging\logger.h" />
     <ClInclude Include="src\logging\single_process_log.h" />

--- a/base/ppfbase/ppfbase.vcxproj.filters
+++ b/base/ppfbase/ppfbase.vcxproj.filters
@@ -101,6 +101,15 @@
     <ClInclude Include="inc\ppfbase\process\this_module.h">
       <Filter>PublicHeaders\process</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppfbase\stdext\iostream.h">
+      <Filter>PublicHeaders\stdext</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ppfbase\stdext\poor_mans_expected.h">
+      <Filter>PublicHeaders\stdext</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ppfbase\stdext\system_error.h">
+      <Filter>PublicHeaders\stdext</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\process\this_process.cpp">

--- a/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
@@ -5,6 +5,7 @@
 #include <ppfbase/preprocessor_utils.h>
 
 #include <set>
+#include <string>
 #include <vector>
 
 namespace tdd::tk::rompatch {
@@ -21,14 +22,6 @@ namespace tdd::tk::rompatch {
 
       FlatPatch Flatten() const;
 
-      void AddValidationData(
-         const size_t address,
-         const DataBuffer& data);
-
-      void AddValidationData(
-         const size_t address,
-         DataBuffer&& data) noexcept;
-
       [[nodiscard]] bool AddPatchData(
          const size_t address,
          const DataBuffer& data);
@@ -37,12 +30,32 @@ namespace tdd::tk::rompatch {
          const size_t address,
          DataBuffer&& data);
 
+      void SetFullPatch(FullPatch&& patch) noexcept;
+
+      void AddValidationData(
+         const size_t address,
+         const DataBuffer& data);
+
+      void AddValidationData(
+         const size_t address,
+         DataBuffer&& data) noexcept;
+
+      void AddFileId(std::string_view id);
+      void AddFileId(std::string&& id);
+
+      void AddDescription(std::string_view description);
+      void AddDescription(std::string&& description);
+
       [[nodiscard]] const ValidationData& GetValidationData() const noexcept;
       [[nodiscard]] const FullPatch& GetFullPatch() const noexcept;
+      [[nodiscard]] const std::string& GetFileId() const noexcept;
+      [[nodiscard]] const std::string& GetDescription() const noexcept;
 
    private:
-      ValidationData m_validationData;
       FullPatch m_fullPatch;
+      ValidationData m_validationData;
+      std::string m_description;
+      std::string m_fileId;
    };
 
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/ppf/parser.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ppf/parser.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <ppftk/rom_patch/patch_descriptor.h>
+#include <ppftk/rom_patch/ppf/ppf3.h>
 
 #include <filesystem>
 #include <optional>
 
 namespace tdd::tk::rompatch::ppf {
 
-   std::optional<PatchDescriptor> Parse(const std::filesystem::path& ppf);
+   std::optional<Ppf3> Parse(const std::filesystem::path& ppf);
 
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/ppf/ppf3.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ppf/ppf3.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <ppftk/rom_patch/patch_descriptor.h>
+
+#include <ppfbase/preprocessor_utils.h>
+
+#include <filesystem>
+
+namespace tdd::tk::rompatch::ppf {
+
+   class [[nodiscard]] Ppf3{
+   public:
+      Ppf3(PatchDescriptor&& patch);
+      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Ppf3);
+
+      [[nodiscard]] const PatchDescriptor::ValidationData&
+         GetValidationData() const noexcept;
+      [[nodiscard]] const PatchDescriptor::FullPatch&
+         GetFullPatch() const noexcept;
+
+      void Compact();
+      [[nodiscard]] bool Compact(std::ifstream& targetImage);
+
+      [[nodiscard]] std::error_code ToFile(
+         const std::filesystem::path& patchPath);
+
+   private:
+      PatchDescriptor m_patch;
+   };
+
+}

--- a/tk/ppftk/ppftk.vcxproj
+++ b/tk/ppftk/ppftk.vcxproj
@@ -15,6 +15,7 @@
     <ClInclude Include="inc\ppftk\rom_patch\patch_descriptor.h" />
     <ClInclude Include="inc\ppftk\rom_patch\patch_item.h" />
     <ClInclude Include="inc\ppftk\rom_patch\ppf\parser.h" />
+    <ClInclude Include="inc\ppftk\rom_patch\ppf\ppf3.h" />
     <ClInclude Include="src\rom_patch\ppf\schema.h" />
     <ClInclude Include="src\rom_patch\ppf\v3.h" />
   </ItemGroup>
@@ -22,6 +23,7 @@
     <ClCompile Include="src\rom_patch\flat_patch.cpp" />
     <ClCompile Include="src\rom_patch\patch_descriptor.cpp" />
     <ClCompile Include="src\rom_patch\ppf\parser.cpp" />
+    <ClCompile Include="src\rom_patch\ppf\ppf3.cpp" />
     <ClCompile Include="src\rom_patch\ppf\v3.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/tk/ppftk/ppftk.vcxproj.filters
+++ b/tk/ppftk/ppftk.vcxproj.filters
@@ -41,6 +41,9 @@
     <ClInclude Include="src\rom_patch\ppf\schema.h">
       <Filter>Source\rom_patch\ppf</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppftk\rom_patch\ppf\ppf3.h">
+      <Filter>PublicHeaders\rom_patch\ppf</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\rom_patch\flat_patch.cpp">
@@ -53,6 +56,9 @@
       <Filter>Source\rom_patch\ppf</Filter>
     </ClCompile>
     <ClCompile Include="src\rom_patch\ppf\v3.cpp">
+      <Filter>Source\rom_patch\ppf</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rom_patch\ppf\ppf3.cpp">
       <Filter>Source\rom_patch\ppf</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tk/ppftk/src/rom_patch/patch_descriptor.cpp
+++ b/tk/ppftk/src/rom_patch/patch_descriptor.cpp
@@ -13,21 +13,6 @@ FlatPatch PatchDescriptor::Flatten() const
    return {};
 }
 
-void PatchDescriptor::AddValidationData(
-   const size_t address,
-   const DataBuffer& data)
-{
-   AddValidationData(address, DataBuffer(data));
-}
-
-void PatchDescriptor::AddValidationData(
-   const size_t address,
-   DataBuffer&& data) noexcept
-{
-   m_validationData.address = address;
-   m_validationData.data = std::move(data);
-}
-
 bool PatchDescriptor::AddPatchData(
    const size_t address,
    const DataBuffer& data)
@@ -47,16 +32,66 @@ bool PatchDescriptor::AddPatchData(
    return inserted;
 }
 
-const PatchDescriptor::ValidationData&
-PatchDescriptor::GetValidationData() const noexcept
+void PatchDescriptor::SetFullPatch(FullPatch&& patch) noexcept
 {
-   return m_validationData;
+   m_fullPatch = std::move(patch);
+}
+
+void PatchDescriptor::AddValidationData(
+   const size_t address,
+   const DataBuffer& data)
+{
+   AddValidationData(address, DataBuffer(data));
+}
+
+void PatchDescriptor::AddValidationData(
+   const size_t address,
+   DataBuffer&& data) noexcept
+{
+   m_validationData.address = address;
+   m_validationData.data = std::move(data);
+}
+
+void PatchDescriptor::AddFileId(std::string_view info)
+{
+   AddFileId(std::string(info));
+}
+
+void PatchDescriptor::AddFileId(std::string&& info)
+{
+   m_fileId = std::move(info);
+}
+
+void PatchDescriptor::AddDescription(std::string_view description)
+{
+   AddDescription(std::string(description));
+}
+
+void PatchDescriptor::AddDescription(std::string&& description)
+{
+   m_description = std::move(description);
 }
 
 const PatchDescriptor::FullPatch&
 PatchDescriptor::GetFullPatch() const noexcept
 {
    return m_fullPatch;
+}
+
+const PatchDescriptor::ValidationData&
+PatchDescriptor::GetValidationData() const noexcept
+{
+   return m_validationData;
+}
+
+const std::string& PatchDescriptor::GetFileId() const noexcept
+{
+   return m_fileId;
+}
+
+const std::string& PatchDescriptor::GetDescription() const noexcept
+{
+   return m_description;
 }
 
 }

--- a/tk/ppftk/src/rom_patch/ppf/parser.cpp
+++ b/tk/ppftk/src/rom_patch/ppf/parser.cpp
@@ -59,7 +59,7 @@ namespace {
    }
 }
 
-std::optional<PatchDescriptor> Parse(const std::filesystem::path& ppf)
+std::optional<Ppf3> Parse(const std::filesystem::path& ppf)
 {
    TDD_ASSERT(ppf.is_absolute());
 

--- a/tk/ppftk/src/rom_patch/ppf/ppf3.cpp
+++ b/tk/ppftk/src/rom_patch/ppf/ppf3.cpp
@@ -1,0 +1,290 @@
+#include <ppftk/rom_patch/ppf/ppf3.h>
+
+#include "schema.h"
+
+#include <ppfbase/logging/logging.h>
+#include <ppfbase/stdext/iostream.h>
+#include <ppfbase/stdext/system_error.h>
+
+#include <fstream>
+
+#include <Windows.h>
+
+namespace tdd::tk::rompatch::ppf {
+
+namespace {
+   namespace v3 = details::ppf::schema;
+
+   void WritePatchEntry(std::ofstream& os, const PatchItem& item)
+   {
+      static constexpr size_t kMaxPayload = std::numeric_limits<uint8_t>::max();
+
+      std::vector<char> entryData(v3::kPatchEntryHeaderSize + kMaxPayload);
+      
+      auto pEntry = reinterpret_cast<v3::PatchEntry*>(entryData.data());
+      pEntry->address = item.address;
+
+      for (auto it = item.data.begin(); it != item.data.end();) {
+         const auto remaining = static_cast<size_t>(
+            std::distance(it, item.data.end()));
+
+         pEntry->length = static_cast<uint8_t>(
+            std::min(remaining, kMaxPayload));
+
+         memcpy_s(pEntry->data, pEntry->length, &(*it), pEntry->length);
+
+         os.write(entryData.data(), v3::kPatchEntryHeaderSize + pEntry->length);
+
+         it+= pEntry->length;
+         pEntry->address += pEntry->length;
+      }
+   }
+
+   void WriteFileId(std::ofstream& os, std::string fileId)
+   {
+      if (fileId.empty()) {
+         return;
+      }
+
+      if (fileId.size() > v3::fileid::kDataMaxLength) {
+         // write a null to the file at the last character.
+         fileId.resize(v3::fileid::kDataMaxLength - 1);
+      }
+
+      auto fileIdLength = static_cast<uint16_t>(fileId.size());
+
+      os.write(v3::fileid::kBegin, v3::fileid::kBeginLength);
+      stdext::Write(os, fileId);
+      if (fileId.back() != '\0') {
+         os.write("\0", 1);
+         ++fileIdLength;
+      }
+
+      os.write(v3::fileid::kEnd, v3::fileid::kEndLength);
+      stdext::Write(os, fileIdLength);
+   }
+
+   [[nodiscard]] bool ValidateTarget(
+      std::ifstream& target,
+      const size_t fileSize,
+      const PatchItem& validationData)
+   {
+      if (validationData.data.empty()) {
+         return true;
+      }
+
+      if (fileSize < validationData.address + validationData.data.size()) {
+         TDD_LOG_ERROR() << "Target image smaller than required";
+         return false;
+      }
+
+      target.seekg(validationData.address, std::ios::beg);
+      if (!target.good()) {
+         TDD_LOG_ERROR() << "Unable to seek to validataion location";
+         return false;
+      }
+
+      DataBuffer targetData(validationData.data.size());
+      stdext::Read(target, targetData);
+      if (!target.good()) {
+         TDD_LOG_ERROR() << "Unable to read target for validation data";
+         return false;
+      }
+
+      if (targetData != validationData.data) {
+         TDD_LOG_ERROR() << "Validation failed";
+         return false;
+      }
+
+      return true;
+   }
+}
+
+Ppf3::Ppf3(PatchDescriptor&& patch)
+   : m_patch(std::move(patch))
+{}
+
+const PatchDescriptor::ValidationData& Ppf3::GetValidationData() const noexcept
+{
+   return m_patch.GetValidationData();
+}
+
+const PatchDescriptor::FullPatch& Ppf3::GetFullPatch() const noexcept
+{
+   return m_patch.GetFullPatch();
+}
+
+void Ppf3::Compact()
+{
+   const auto& patch = m_patch.GetFullPatch();
+
+   if (patch.empty()) {
+      TDD_LOG_DEBUG() << "Nothing to compact";
+      return;
+   }
+
+   PatchDescriptor::FullPatch compacted;
+   PatchItem merged{};
+
+   for (const auto& entry : patch) {
+      if (entry.data.empty()) {
+         continue;
+      }
+
+      if (merged.address + merged.data.size() == entry.address) {
+         merged.data.insert(
+            merged.data.end(),
+            entry.data.begin(),
+            entry.data.end());
+         continue;
+      }
+
+      if (!merged.data.empty()) {
+         compacted.insert(merged);
+      }
+      merged = entry;
+   }
+
+   if (!merged.data.empty()) {
+      compacted.insert(merged);
+   }
+
+   m_patch.SetFullPatch(std::move(compacted));
+}
+
+bool Ppf3::Compact(std::ifstream& targetImage)
+{
+   const auto& patch = m_patch.GetFullPatch();
+   if (patch.empty()) {
+      TDD_LOG_DEBUG() << "Nothing to compact";
+      return true;
+   }
+
+   targetImage.seekg(0, std::ios::end);
+   const size_t fileSize = targetImage.tellg();
+
+   if (!ValidateTarget(targetImage, fileSize, m_patch.GetValidationData())) {
+      return false;
+   }
+
+   PatchDescriptor::FullPatch compacted;
+   PatchItem merged{};
+
+   for (const auto& entry : patch) {
+      if (entry.data.empty()) {
+         continue;
+      }
+
+      const auto currentEndAddress = merged.address + merged.data.size();
+      const auto gap = entry.address - currentEndAddress;
+
+      // If the gap is less than equal to the entry header size, we can save
+      // space by pulling in the data from the target image.
+      if (gap <= v3::kPatchEntryHeaderSize) {
+         if (gap > 0) {
+            if (currentEndAddress + gap + entry.data.size() > fileSize) {
+               TDD_LOG_ERROR() << "Patch does not apply to the target image";
+               return false;
+            }
+
+            targetImage.seekg(currentEndAddress, std::ios::beg);
+            if (!targetImage.good()) {
+               TDD_LOG_ERROR() << "Unable to seek to filler location";
+               return false;
+            }
+
+            DataBuffer filler(gap);
+            stdext::Read(targetImage, filler);
+            if (!targetImage.good()) {
+               TDD_LOG_ERROR() << "Unable to read target image for filler data";
+               return false;
+            }
+
+            merged.data.insert(
+               merged.data.end(),
+               filler.begin(),
+               filler.end());
+         }
+
+         merged.data.insert(
+            merged.data.end(),
+            entry.data.begin(),
+            entry.data.end());
+         continue;
+      }
+
+      if (!merged.data.empty()) {
+         compacted.insert(merged);
+      }
+      merged = entry;
+   }
+
+   if (!merged.data.empty()) {
+      compacted.insert(merged);
+   }
+
+   m_patch.SetFullPatch(std::move(compacted));
+
+   return true;
+}
+
+std::error_code Ppf3::ToFile(const std::filesystem::path& patchPath)
+{
+   
+   std::ofstream patch;
+   patch.exceptions(0);
+   patch.open(patchPath, std::ofstream::binary | std::ofstream::trunc);
+   if (!patch.good()) {
+      TDD_LOG_ERROR() << "Unable to create file: [" << patchPath.wstring()
+         << "]";
+      return stdext::make_win32_ec(static_cast<uint32_t>(E_FAIL));
+   }
+
+   v3::Header header{0};
+   memcpy_s(
+      header.magic,
+      sizeof(header.magic),
+      v3::kMagic3,
+      std::char_traits<char>::length(v3::kMagic3));
+
+   header.encoding = v3::Encoding::PPF3;
+
+   const auto& desc = m_patch.GetDescription();
+   if (desc.size() > sizeof(header.description)) {
+      TDD_LOG_WARN() << "Description is longer than allowed length. Truncated.";
+   }
+
+   memcpy_s(
+      header.description,
+      sizeof(header.description),
+      desc.c_str(),
+      desc.size());
+
+   const auto& validationData = m_patch.GetValidationData();
+   if (validationData.address == v3::kPrimoDvdValidationAddress) {
+      header.imageType = v3::TargetImageType::PrimoDvd;
+   }
+   else {
+      header.imageType = v3::TargetImageType::Any;
+   }
+   
+   header.validateImage = !validationData.data.empty();
+   header.hasUndoData = false;
+
+   stdext::Write(patch, header);
+
+   if (header.validateImage) {
+      stdext::Write(patch, validationData.data);
+   }
+
+   for (const auto& entry : m_patch.GetFullPatch()) {
+      WritePatchEntry(patch, entry);
+   }
+
+   WriteFileId(patch, m_patch.GetFileId());
+   patch.close();
+
+   return {};
+}
+
+}

--- a/tk/ppftk/src/rom_patch/ppf/schema.h
+++ b/tk/ppftk/src/rom_patch/ppf/schema.h
@@ -1,6 +1,10 @@
 #pragma once
+#include <string>
 
 namespace tdd::tk::rompatch::details::ppf::schema {
+   inline constexpr auto kMagic1 = "PPF10";
+   inline constexpr auto kMagic2 = "PPF20";
+   inline constexpr auto kMagic3 = "PPF30";
 
    enum class [[nodiscard]] Encoding : char
    {
@@ -14,4 +18,54 @@ namespace tdd::tk::rompatch::details::ppf::schema {
       Any = 0,
       PrimoDvd = 1
    };
+
+#pragma pack(push, 1)
+   struct [[nodiscard]] Header
+   {
+      char magic[5];
+      schema::Encoding encoding;
+      char description[50];
+      schema::TargetImageType imageType;
+      bool validateImage;
+      bool hasUndoData;
+      bool dummy;
+   };
+   static_assert(sizeof(Header) == 60);
+
+   // Present after the Header if 'validateImage' is true.
+   inline constexpr size_t kValidataionDataLength = 1024;
+   // Address in the target file where validation data is located.
+   inline constexpr size_t kAnyImageValidationAddress = 0x9320;
+   inline constexpr size_t kPrimoDvdValidationAddress = 0x80A0;
+
+   struct [[nodiscard]] PatchEntry
+   {
+      uint64_t address;
+      uint8_t length;
+      char data[1];
+   };
+
+   inline constexpr auto kPatchEntryHeaderSize = sizeof(uint64_t) + sizeof(uint8_t);
+
+#pragma pack(pop)
+
+   namespace fileid {
+      // If the patch has a FILE_ID.DIZ, its length is the last two bytes of the
+      // file. '@END_FILE_ID.DIZ' magic string immediately precedes these two bytes.
+      inline constexpr int kLengthSize = 2;
+
+      inline constexpr auto kBegin = "@BEGIN_FILE_ID.DIZ";
+      inline constexpr auto kBeginLength = std::char_traits<char>::length(kBegin);
+
+      inline constexpr auto kEnd = "@END_FILE_ID.DIZ";
+      inline constexpr auto kEndLength = std::char_traits<char>::length(kEnd);
+
+      // The data could be longer. But PPF3.txt says it's 3072.
+      inline constexpr size_t kDataMaxLength = 3072;
+
+      inline constexpr int kEndPos = -static_cast<int>(kLengthSize + kEndLength);
+
+      inline constexpr size_t kTotalPadding = kLengthSize + kBeginLength + kEndLength;
+   }
+
 }


### PR DESCRIPTION
* Add pm_expected, the poor man's std::expected.
* Add make_win32_ec.
* Move istream reading helpers to stdext.

* Add file id to PatchDescriptor.
* Move PPF3 layout related things to schema.h.
* Get the file id string.

* Add PPF3 class to manipulate patch data in accordance with the PPF3 file format.