### PR TITLE
ppfinjector#18: Flat Patch

### DIFF
--- a/app/patchtester/src/patchtester.cpp
+++ b/app/patchtester/src/patchtester.cpp
@@ -1,4 +1,6 @@
+#include <ppftk/rom_patch/flat_patch.h>
 #include <ppftk/rom_patch/ppf/parser.h>
+#include <ppftk/rom_patch/ppf/ppf3.h>
 
 #include <ppfbase/logging/logging.h>
 
@@ -38,7 +40,7 @@ int main()
    //   << std::endl;
 
    auto target = std::ifstream(testTarget, std::ios::binary);
-   if (!patch->Compact(target)) {
+   if (!patch->Compact(target, 128)) {
       std::cout << "Unable to compact with fillers";
       return 2;
    }
@@ -46,12 +48,17 @@ int main()
    std::cout << "Patch entries: " << patch->GetFullPatch().size()
       << std::endl;
 
-   if (patch->ToFile(compactedPatch)) {
+   if (tdd::tk::rompatch::ppf::WritePpf3Patch(compactedPatch, patch.value())) {
       std::cout << "Unable to write compacted PFF" << std::endl;
    }
    else {
       std::cout << "Compacted patch saved" << std::endl;
    }
+
+   const auto flatPatch = patch->Flatten();
+   std::cout << "Flattend patch has "
+      << std::distance(flatPatch.begin(), flatPatch.end()) << " entries"
+      << std::endl;
 
    return 0;
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <ppftk/rom_patch/patch_item.h>
-
-#include <ppfbase/preprocessor_utils.h>
+#include <ppftk/rom_patch/patch_descriptor.h>
 
 #include <vector>
 
@@ -10,15 +8,101 @@ namespace tdd::tk::rompatch {
 
    class [[nodiscard]] FlatPatch
    {
+   private:
+      using FlattenedPatches = std::vector<uint64_t>;
    public:
       using ValidationData = PatchItem;
 
+      // sizeof(PatchBlock) = 3 * sizeof(uint64_t) + (patchLength + 7) & ~0b111
+      struct PatchBlock
+      {
+         uint64_t address;
+         // byte count of the size of the patch
+         uint64_t patchLength;
+         // previous = (char*)this - previousBlockOffset
+         uint64_t previousBlockOffset;
+         // patch is always a multiple of 8 to keep PatchBlock 8-byte aligned.
+         uint64_t patch[1];
+      };
+
+      using value_type = PatchBlock;
+      using size_type = size_t;
+      using difference_type = std::ptrdiff_t;
+      using pointer = PatchBlock const *;
+      using const_pointer = pointer;
+      using reference = PatchBlock const &;
+      using const_reference = reference;
+
+
+      class [[nodiscard]] Iterator
+      {
+      public:
+         using iterator_concept = std::bidirectional_iterator_tag;
+         using iterator_category = std::bidirectional_iterator_tag;
+
+         using value_type = FlatPatch::value_type;
+         using difference_type = FlatPatch::difference_type;
+         using pointer = FlatPatch::const_pointer;
+         using reference = FlatPatch::reference;
+
+         TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Iterator);
+
+         reference operator*() const noexcept;
+         pointer operator->() const noexcept;
+
+         Iterator& operator++() noexcept;
+         Iterator operator++(int) noexcept;
+
+         Iterator& operator--() noexcept;
+         Iterator operator--(int) noexcept;
+
+         [[nodiscard]] bool operator==(const Iterator& other) const = default;
+
+      private:
+         friend class FlatPatch;
+
+         Iterator(
+            FlatPatch const* parent,
+            FlattenedPatches::const_iterator pos);
+
+         FlatPatch const* m_parent;
+         FlattenedPatches::const_iterator m_pos;
+      };
+
+      FlatPatch(const PatchDescriptor descriptor);
+
       TDD_DEFAULT_ALL_SPECIAL_MEMBERS(FlatPatch);
 
+      using iterator = Iterator;
+
+      iterator begin() const noexcept;
+      iterator end() const noexcept;
+
+      void Patch(
+         const uint64_t addr,
+         const uint64_t size,
+         char* buffer) const noexcept;
 
    private:
+      [[nodiscard]] bool IsInRange(
+         const uint64_t targetAddrBegin,
+         const uint64_t targetAddrEnd) const;
+
+      // Returns true if a usable block is found
+      [[nodiscard]] bool SeekForward(
+         const uint64_t targetAddrBegin,
+         const uint64_t targetAddrEnd) const;
+
+      [[nodiscard]] bool SeekBackward(
+         const uint64_t targetAddrBegin,
+         const uint64_t targetAddrEnd) const;
+
       ValidationData m_validationData;
-      DataBuffer m_patch;
+      FlattenedPatches m_patch;
+
+      iterator m_back;
+      mutable iterator m_lastRead;
+      
    };
 
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
@@ -4,6 +4,8 @@
 
 #include <ppfbase/preprocessor_utils.h>
 
+#include <fstream>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -21,6 +23,11 @@ namespace tdd::tk::rompatch {
       TDD_DEFAULT_ALL_SPECIAL_MEMBERS(PatchDescriptor);
 
       FlatPatch Flatten() const;
+
+      void Compact();
+      [[nodiscard]] bool Compact(
+         std::ifstream& targetImage,
+         std::optional<size_t> gapSizeToFillOverride = std::nullopt);
 
       [[nodiscard]] bool AddPatchData(
          const size_t address,

--- a/tk/ppftk/inc/ppftk/rom_patch/ppf/parser.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ppf/parser.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include <ppftk/rom_patch/ppf/ppf3.h>
+#include <ppftk/rom_patch/patch_descriptor.h>
 
 #include <filesystem>
 #include <optional>
 
 namespace tdd::tk::rompatch::ppf {
 
-   std::optional<Ppf3> Parse(const std::filesystem::path& ppf);
+   std::optional<PatchDescriptor> Parse(const std::filesystem::path& ppf);
 
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/ppf/ppf3.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ppf/ppf3.h
@@ -2,30 +2,12 @@
 
 #include <ppftk/rom_patch/patch_descriptor.h>
 
-#include <ppfbase/preprocessor_utils.h>
-
 #include <filesystem>
 
 namespace tdd::tk::rompatch::ppf {
 
-   class [[nodiscard]] Ppf3{
-   public:
-      Ppf3(PatchDescriptor&& patch);
-      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Ppf3);
-
-      [[nodiscard]] const PatchDescriptor::ValidationData&
-         GetValidationData() const noexcept;
-      [[nodiscard]] const PatchDescriptor::FullPatch&
-         GetFullPatch() const noexcept;
-
-      void Compact();
-      [[nodiscard]] bool Compact(std::ifstream& targetImage);
-
-      [[nodiscard]] std::error_code ToFile(
-         const std::filesystem::path& patchPath);
-
-   private:
-      PatchDescriptor m_patch;
-   };
+   [[nodiscard]] std::error_code WritePpf3Patch(
+      const std::filesystem::path& ppf3Path,
+      const PatchDescriptor& patch);
 
 }

--- a/tk/ppftk/src/rom_patch/flat_patch.cpp
+++ b/tk/ppftk/src/rom_patch/flat_patch.cpp
@@ -1,0 +1,255 @@
+#include <ppftk/rom_patch/flat_patch.h>
+
+#include <ppfbase/logging/logging.h>
+
+namespace tdd::tk::rompatch {
+
+namespace {
+   // Counts the number 'uint64_t's required.
+   static constexpr size_t kFlattenedHeader = 3;
+
+
+   // The FlattenedPatches is in 'uint64_t'. This returns the count in terms
+   // 'uint64_t'.
+   [[nodiscard]] ptrdiff_t GetBlockSize(FlatPatch::PatchBlock const* block)
+   {
+      static constexpr size_t kHeaderSize = 3;
+      const auto patchSize =
+         (block->patchLength + sizeof(uint64_t) - 1) / sizeof(uint64_t);
+      return kHeaderSize + patchSize;
+   }
+
+   [[nodiscard]] ptrdiff_t GetPreviousBlockOffset(
+      FlatPatch::PatchBlock const* block)
+   {
+      TDD_ASSERT(0 == block->previousBlockOffset % sizeof(uint64_t));
+
+      return -static_cast<ptrdiff_t>(block->previousBlockOffset / sizeof(uint64_t));
+   }
+
+   [[nodiscard]] size_t GetFlattenedSize(const PatchItem& patch)
+   {
+      const size_t dataLength =
+         (patch.data.size() + sizeof(uint64_t) - 1) / sizeof(uint64_t);
+      return kFlattenedHeader + dataLength;
+   }
+}
+
+FlatPatch::Iterator::reference FlatPatch::Iterator::operator*() const noexcept
+{
+   return *operator->();
+}
+
+FlatPatch::Iterator::pointer FlatPatch::Iterator::operator->() const noexcept
+{
+   TDD_ASSERT(nullptr != m_parent);
+   TDD_ASSERT(m_pos != m_parent->m_patch.end());
+   return reinterpret_cast<pointer>(&(*m_pos));
+}
+
+FlatPatch::Iterator& FlatPatch::Iterator::operator++() noexcept
+{
+   TDD_ASSERT(nullptr != m_parent);
+
+   const auto offset = GetBlockSize(this->operator->());
+   TDD_ASSERT(offset <= std::distance(m_pos, m_parent->m_patch.end()));
+
+   std::advance(m_pos, offset);
+   return *this;
+}
+
+FlatPatch::Iterator FlatPatch::Iterator::operator++(int) noexcept
+{
+   Iterator tmp = *this;
+   this->operator++();
+   return tmp;
+}
+
+FlatPatch::Iterator& FlatPatch::Iterator::operator--() noexcept
+{
+   TDD_ASSERT(nullptr != m_parent);
+
+   if (m_pos == m_parent->m_patch.end()) {
+      m_pos = m_parent->m_back.m_pos;
+      return *this;
+   }
+
+   const auto offset = GetPreviousBlockOffset(this->operator->());
+   TDD_ASSERT(std::distance(m_pos, m_parent->m_patch.begin()) <= offset);
+
+   std::advance(m_pos, offset);
+   return *this;
+}
+
+FlatPatch::Iterator FlatPatch::Iterator::operator--(int) noexcept
+{
+   Iterator tmp = *this;
+   this->operator--();
+   return tmp;
+}
+
+FlatPatch::Iterator::Iterator(
+   FlatPatch const* parent,
+   FlattenedPatches::const_iterator pos)
+   : m_parent(parent)
+   , m_pos(pos)
+{}
+
+
+FlatPatch::FlatPatch(const PatchDescriptor descriptor)
+   : m_validationData(descriptor.GetValidationData())
+   , m_patch()
+   , m_back()
+   , m_lastRead()
+{
+   static constexpr size_t kInitialAllowancePerPatch = 8;
+   
+   TDD_ASSERT(!descriptor.GetFullPatch().empty());
+
+   m_patch.reserve(
+      kInitialAllowancePerPatch * descriptor.GetFullPatch().size());
+
+   std::vector<uint64_t> blockBuffer;
+   size_t previousBlockOffset = 0;
+
+   const auto& patches = descriptor.GetFullPatch();
+
+   for (const auto& p : patches) {
+      const auto requiredSize = GetFlattenedSize(p);
+      blockBuffer.clear();
+      blockBuffer.resize(requiredSize);
+
+      auto* block = reinterpret_cast<PatchBlock*>(blockBuffer.data());
+      block->address = p.address;
+      block->patchLength = p.data.size();
+      block->previousBlockOffset = previousBlockOffset;
+      memcpy_s(
+         block->patch,
+         (requiredSize - kFlattenedHeader) * sizeof(uint64_t),
+         p.data.data(),
+         p.data.size());
+
+      previousBlockOffset = requiredSize;
+
+      m_patch.insert(m_patch.end(), blockBuffer.begin(), blockBuffer.end());
+   }
+
+   m_lastRead = begin();
+   m_back = Iterator(this, m_patch.end() - previousBlockOffset);
+}
+
+FlatPatch::iterator FlatPatch::begin() const noexcept
+{
+   return Iterator(this, m_patch.begin());
+}
+
+FlatPatch::iterator FlatPatch::end() const noexcept
+{
+   return Iterator(this, m_patch.end());
+}
+
+void FlatPatch::Patch(
+   const uint64_t addr,
+   const uint64_t size,
+   char* buffer) const noexcept
+{
+   const auto endAddr = addr + size;
+
+   if (!IsInRange(addr, endAddr)) {
+      return;
+   }
+
+   if (addr < m_lastRead->address) {
+      if (!SeekBackward(addr, endAddr)) {
+         return;
+      }
+   }
+   else if (addr > m_lastRead->address) {
+      if (!SeekForward(addr, endAddr)) {
+         return;
+      }
+   }
+
+   // patch data
+   if (m_lastRead->address < addr) {
+      // Target buffer starts in the middle of a patch.
+      const auto offset = m_lastRead->address - addr;
+      memcpy_s(
+         buffer,
+         size,
+         reinterpret_cast<const uint8_t*>(m_lastRead->patch) + offset,
+         m_lastRead->patchLength - offset);
+      ++m_lastRead;
+   }
+
+   while (m_lastRead != end() && m_lastRead->address < endAddr) {
+      const auto offset = m_lastRead->address - addr;
+      const auto availableBufferSize = size - offset;
+      memcpy_s(
+         buffer + offset,
+         availableBufferSize,
+         m_lastRead->patch,
+         m_lastRead->patchLength);
+
+      ++m_lastRead;
+   }
+
+   --m_lastRead;
+}
+
+bool FlatPatch::IsInRange(
+   const uint64_t targetAddrBegin,
+   const uint64_t targetAddrEnd) const
+{
+   if (targetAddrEnd < begin()->address) {
+      return false;
+   }
+
+   if (targetAddrBegin > m_back->address + m_back->patchLength) {
+      return false;
+   }
+
+   return true;
+}
+
+bool FlatPatch::SeekForward(
+   const uint64_t targetAddrBegin,
+   const uint64_t targetAddrEnd) const
+{
+   while (m_lastRead != end()) {
+      if (m_lastRead->address >= targetAddrEnd) {
+         return false;
+      }
+
+      if (m_lastRead->address + m_lastRead->patchLength > targetAddrBegin) {
+         return true;
+      }
+
+      if (targetAddrEnd > m_lastRead->address) {
+         return true;
+      }
+      ++m_lastRead;
+   }
+
+   if (m_lastRead == end()) {
+      m_lastRead = m_back;
+   }
+   return false;
+}
+
+bool FlatPatch::SeekBackward(
+   const uint64_t targetAddr,
+   const uint64_t targetAddrEnd) const
+{
+   do {
+      --m_lastRead;
+      if (targetAddr > m_lastRead->address) {
+         break;
+      }
+
+   }
+   while (m_lastRead != begin());
+   return SeekForward(targetAddr, targetAddrEnd);
+}
+
+}

--- a/tk/ppftk/src/rom_patch/patch_descriptor.cpp
+++ b/tk/ppftk/src/rom_patch/patch_descriptor.cpp
@@ -1,16 +1,173 @@
 #include <ppftk/rom_patch/patch_descriptor.h>
 
+#include "ppf/schema.h"
+
 #include <ppftk/rom_patch/flat_patch.h>
 
 #include <ppfbase/logging/logging.h>
+#include <ppfbase/stdext/iostream.h>
 
 namespace tdd::tk::rompatch {
 
+namespace {
+   [[nodiscard]] bool ValidateTarget(
+      std::ifstream& target,
+      const size_t fileSize,
+      const PatchItem& validationData)
+   {
+      if (validationData.data.empty()) {
+         return true;
+      }
+
+      if (fileSize < validationData.address + validationData.data.size()) {
+         TDD_LOG_ERROR() << "Target image smaller than required";
+         return false;
+      }
+
+      target.seekg(validationData.address, std::ios::beg);
+      if (!target.good()) {
+         TDD_LOG_ERROR() << "Unable to seek to validataion location";
+         return false;
+      }
+
+      DataBuffer targetData(validationData.data.size());
+      stdext::Read(target, targetData);
+      if (!target.good()) {
+         TDD_LOG_ERROR() << "Unable to read target for validation data";
+         return false;
+      }
+
+      if (targetData != validationData.data) {
+         TDD_LOG_ERROR() << "Validation failed";
+         return false;
+      }
+
+      return true;
+   }
+}
+
 FlatPatch PatchDescriptor::Flatten() const
 {
-   // TODO: implement
-   TDD_ASSERT(false);
-   return {};
+   return FlatPatch(*this);
+}
+
+void PatchDescriptor::Compact()
+{
+   const auto& patch = std::as_const(m_fullPatch);
+
+   if (patch.empty()) {
+      TDD_LOG_DEBUG() << "Nothing to compact";
+      return;
+   }
+
+   FullPatch compacted;
+   PatchItem merged{};
+
+   for (const auto& entry : patch) {
+      if (entry.data.empty()) {
+         continue;
+      }
+
+      if (merged.address + merged.data.size() == entry.address) {
+         merged.data.insert(
+            merged.data.end(),
+            entry.data.begin(),
+            entry.data.end());
+         continue;
+      }
+
+      if (!merged.data.empty()) {
+         compacted.insert(merged);
+      }
+      merged = entry;
+   }
+
+   if (!merged.data.empty()) {
+      compacted.insert(merged);
+   }
+
+   m_fullPatch = std::move(compacted);
+}
+
+bool PatchDescriptor::Compact(
+   std::ifstream& targetImage,
+   std::optional<size_t> gapSizeToFillOverride)
+{
+   const auto& patch = std::as_const(m_fullPatch);
+   if (patch.empty()) {
+      TDD_LOG_DEBUG() << "Nothing to compact";
+      return true;
+   }
+
+   targetImage.seekg(0, std::ios::end);
+   const size_t fileSize = targetImage.tellg();
+
+   if (!ValidateTarget(targetImage, fileSize, GetValidationData())) {
+      return false;
+   }
+
+   const auto gapSizeToFill = gapSizeToFillOverride.value_or(
+      details::ppf::schema::kPatchEntryHeaderSize);
+
+   PatchDescriptor::FullPatch compacted;
+   PatchItem merged{};
+
+   for (const auto& entry : patch) {
+      if (entry.data.empty()) {
+         continue;
+      }
+
+      const auto currentEndAddress = merged.address + merged.data.size();
+      const auto gap = entry.address - currentEndAddress;
+
+      // If the gap is less than equal to the entry header size, we can save
+      // space by pulling in the data from the target image.
+      if (gap <= gapSizeToFill) {
+         if (gap > 0) {
+            if (currentEndAddress + gap + entry.data.size() > fileSize) {
+               TDD_LOG_ERROR() << "Patch does not apply to the target image";
+               return false;
+            }
+
+            targetImage.seekg(currentEndAddress, std::ios::beg);
+            if (!targetImage.good()) {
+               TDD_LOG_ERROR() << "Unable to seek to filler location";
+               return false;
+            }
+
+            DataBuffer filler(gap);
+            stdext::Read(targetImage, filler);
+            if (!targetImage.good()) {
+               TDD_LOG_ERROR() << "Unable to read target image for filler data";
+               return false;
+            }
+
+            merged.data.insert(
+               merged.data.end(),
+               filler.begin(),
+               filler.end());
+         }
+
+         merged.data.insert(
+            merged.data.end(),
+            entry.data.begin(),
+            entry.data.end());
+         continue;
+      }
+
+      if (!merged.data.empty()) {
+         compacted.insert(merged);
+      }
+      merged = entry;
+   }
+
+   if (!merged.data.empty()) {
+      compacted.insert(merged);
+   }
+
+   m_fullPatch = std::move(compacted);
+
+   return true;
 }
 
 bool PatchDescriptor::AddPatchData(

--- a/tk/ppftk/src/rom_patch/ppf/parser.cpp
+++ b/tk/ppftk/src/rom_patch/ppf/parser.cpp
@@ -59,7 +59,7 @@ namespace {
    }
 }
 
-std::optional<Ppf3> Parse(const std::filesystem::path& ppf)
+std::optional<PatchDescriptor> Parse(const std::filesystem::path& ppf)
 {
    TDD_ASSERT(ppf.is_absolute());
 


### PR DESCRIPTION
* Move Compact to PatchDescriptor.
* Add an optional gap size for Compact to fill when compacting patch entries.
* Turn Ppf3 into a free function for creating a PPF3 file.

* Implement FlatPatch.
* Flatten PatchDescriptor.