### PR TITLE
ppfinjector#22: Wire ReadFileHook up to FlatPatch

### DIFF
--- a/app/patchtester/src/patchtester.cpp
+++ b/app/patchtester/src/patchtester.cpp
@@ -2,10 +2,70 @@
 #include <ppftk/rom_patch/ppf/parser.h>
 #include <ppftk/rom_patch/ppf/ppf3.h>
 
+#include <ppfbase/branding.h>
 #include <ppfbase/logging/logging.h>
+#include <ppfbase/process/this_process.h>
+#include <ppfbase/stdext/iostream.h>
 
 #include <fstream>
 #include <iostream>
+
+#include <Windows.h>
+
+namespace tdd::app::patchtester {
+   void TestInjector()
+   {
+      static constexpr size_t kBufferSize = 20480;
+
+      static const std::filesystem::path targetFile(
+         "C:\\dev\\ppfinjector\\app\\patchtester\\data\\SotN-Randomizer (1691056147921).bin");
+
+      static const std::filesystem::path verificationFile(
+         "C:\\dev\\ppfinjector\\app\\patchtester\\data\\verification.bin");
+
+
+      auto& launcher = base::process::ThisProcess::ImagePath();
+      const auto injectorPath =
+         (launcher.parent_path() / TDD_PPF_INJECTOR_DLL_W).wstring();
+
+      const auto hInjector = ::LoadLibraryW(injectorPath.c_str());
+      if (NULL == hInjector) {
+         std::cout << "Unable to load injector." << std::endl;
+         return;
+      }
+
+      std::ifstream target(targetFile, std::ios::binary);
+      std::ifstream verification(verificationFile, std::ios::binary);
+
+      std::vector<char> tBuf(kBufferSize);
+      std::vector<char> vBuf(kBufferSize);
+
+      verification.seekg(0, std::ios::end);
+      size_t read = 0;
+      size_t left = verification.tellg();
+      verification.seekg(0, std::ios::beg);
+      while (left > 0) {
+         if (left < kBufferSize) {
+            tBuf.resize(left);
+            vBuf.resize(left);
+         }
+
+         stdext::Read(target, tBuf);
+         stdext::Read(verification, vBuf);
+
+         if (tBuf != vBuf) {
+            std::cout << "Mismatch at " << read << std::endl;
+            return;
+         }
+         read += tBuf.size();
+         left -= tBuf.size();
+      }
+
+      std::cout << "Identical data read. Patch injector is working"
+         << std::endl;
+
+   }
+}
 
 int main()
 {
@@ -39,26 +99,38 @@ int main()
    //std::cout << "Patch entries: " << patch->GetFullPatch().size()
    //   << std::endl;
 
-   auto target = std::ifstream(testTarget, std::ios::binary);
-   if (!patch->Compact(target, 128)) {
-      std::cout << "Unable to compact with fillers";
-      return 2;
-   }
-   std::cout << "After compact" << std::endl;
-   std::cout << "Patch entries: " << patch->GetFullPatch().size()
-      << std::endl;
+   {
+      auto target = std::ifstream(testTarget, std::ios::binary);
+      if (!patch->Compact(target, 128)) {
+         std::cout << "Unable to compact with fillers";
+         return 2;
+      }
+      std::cout << "After compact" << std::endl;
+      std::cout << "Patch entries: " << patch->GetFullPatch().size()
+         << std::endl;
 
-   if (tdd::tk::rompatch::ppf::WritePpf3Patch(compactedPatch, patch.value())) {
-      std::cout << "Unable to write compacted PFF" << std::endl;
-   }
-   else {
-      std::cout << "Compacted patch saved" << std::endl;
+      if (tdd::tk::rompatch::ppf::WritePpf3Patch(compactedPatch, patch.value())) {
+         std::cout << "Unable to write compacted PFF" << std::endl;
+      }
+      else {
+         std::cout << "Compacted patch saved" << std::endl;
+      }
+
+      const auto flatPatch = patch->Flatten();
+      const auto patchCount = std::distance(flatPatch.begin(), flatPatch.end());
+      std::cout << "Flattend patch has " << patchCount << " entries" << std::endl;
+
+      auto lastFromEnd = flatPatch.end();
+      --lastFromEnd;
+      auto lastFromBegin = flatPatch.begin();
+      std::advance(lastFromBegin, patchCount - 1);
+      if (lastFromBegin != lastFromEnd) {
+         std::cout << "Last iterator not equal" << std::endl;
+      }
    }
 
-   const auto flatPatch = patch->Flatten();
-   std::cout << "Flattend patch has "
-      << std::distance(flatPatch.begin(), flatPatch.end()) << " entries"
-      << std::endl;
+
+   tdd::app::patchtester::TestInjector();
 
    return 0;
 }

--- a/app/ppfinjector/ppfinjector.vcxproj
+++ b/app/ppfinjector/ppfinjector.vcxproj
@@ -83,6 +83,9 @@
     <ProjectReference Include="..\..\deps\detours\detours.vcxproj">
       <Project>{3b717b2a-edb5-42a0-ade7-c361629ffe22}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\tk\ppftk\ppftk.vcxproj">
+      <Project>{5561b3c1-3815-4992-9848-dcc234db7539}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\hook_status.cpp" />

--- a/base/ppfbase/inc/ppfbase/filesystem/file.h
+++ b/base/ppfbase/inc/ppfbase/filesystem/file.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <optional>
+
+#include <Windows.h>
+
+namespace tdd::base::fs::File {
+
+   [[nodiscard]] std::optional<int64_t> GetFilePointer(const HANDLE hFile);
+}

--- a/base/ppfbase/ppfbase.vcxproj
+++ b/base/ppfbase/ppfbase.vcxproj
@@ -15,6 +15,7 @@
     <ClInclude Include="inc\ppfbase\chrono\timestamp.h" />
     <ClInclude Include="inc\ppfbase\diagnostics\assert.h" />
     <ClInclude Include="inc\ppfbase\diagnostics\debugger.h" />
+    <ClInclude Include="inc\ppfbase\filesystem\file.h" />
     <ClInclude Include="inc\ppfbase\filesystem\path_service.h" />
     <ClInclude Include="inc\ppfbase\logging\ilog.h" />
     <ClInclude Include="inc\ppfbase\logging\logging.h" />
@@ -36,6 +37,7 @@
   <ItemGroup>
     <ClCompile Include="src\chrono\timestamp.cpp" />
     <ClCompile Include="src\diagnostics\debugger.cpp" />
+    <ClCompile Include="src\filesystem\file.cpp" />
     <ClCompile Include="src\filesystem\path_service.cpp" />
     <ClCompile Include="src\logging\basic_log.cpp" />
     <ClCompile Include="src\logging\logger.cpp" />

--- a/base/ppfbase/ppfbase.vcxproj.filters
+++ b/base/ppfbase/ppfbase.vcxproj.filters
@@ -110,6 +110,9 @@
     <ClInclude Include="inc\ppfbase\stdext\system_error.h">
       <Filter>PublicHeaders\stdext</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppfbase\filesystem\file.h">
+      <Filter>PublicHeaders\filesystem</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\process\this_process.cpp">
@@ -147,6 +150,9 @@
     </ClCompile>
     <ClCompile Include="src\process\this_module.cpp">
       <Filter>Source\process</Filter>
+    </ClCompile>
+    <ClCompile Include="src\filesystem\file.cpp">
+      <Filter>Source\filesystem</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/base/ppfbase/src/filesystem/file.cpp
+++ b/base/ppfbase/src/filesystem/file.cpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <ppfbase/filesystem/file.h>
+#include <ppfbase/logging/logging.h>
+
+namespace tdd::base::fs::File {
+
+std::optional<int64_t> GetFilePointer(const HANDLE hFile)
+{
+   static constexpr LARGE_INTEGER kDontMoveFilePointer{ 0 };
+
+   LARGE_INTEGER location{ 0 };
+   const auto success = SetFilePointerEx(
+      hFile,
+      kDontMoveFilePointer,
+      &location,
+      FILE_CURRENT);
+
+   if (success) {
+      return location.QuadPart;
+   }
+
+   const auto err = GetLastError();
+   TDD_LOG_WARN() << "Unable to get current file pointer location: "
+      << std::error_code(err, std::system_category());
+   return std::nullopt;
+}
+}

--- a/ppfinjector.sln
+++ b/ppfinjector.sln
@@ -25,6 +25,9 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "emulauncher", "app\emulaunc
 	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "patchtester", "app\patchtester\patchtester.vcxproj", "{69703376-A12E-4EA1-8355-F8378DBF8146}"
+	ProjectSection(ProjectDependencies) = postProject
+		{E5EB2B94-4E44-4F3F-97BF-4025227C8239} = {E5EB2B94-4E44-4F3F-97BF-4025227C8239}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
@@ -69,14 +69,21 @@ namespace tdd::tk::rompatch {
          FlattenedPatches::const_iterator m_pos;
       };
 
+      TDD_DEFAULT_CTOR_DTOR(FlatPatch);
+
       FlatPatch(const PatchDescriptor descriptor);
 
-      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(FlatPatch);
+      FlatPatch(const FlatPatch& other);
+      FlatPatch& operator=(const FlatPatch& other) noexcept;
+
+      FlatPatch(FlatPatch&& other);
+      FlatPatch& operator=(FlatPatch&& other) noexcept;
 
       using iterator = Iterator;
 
       iterator begin() const noexcept;
       iterator end() const noexcept;
+      [[nodiscard]] bool empty() const noexcept;
 
       void Patch(
          const uint64_t addr,

--- a/tk/ppftk/src/rom_patch/ppf/v3.cpp
+++ b/tk/ppftk/src/rom_patch/ppf/v3.cpp
@@ -196,6 +196,7 @@ std::optional<PatchDescriptor> Parse(std::istream& ppf)
       return std::nullopt;
    }
 
+   patch.Compact();
    return patch;
 }
 


### PR DESCRIPTION
* Move GetFilePointer to base::fs::File.
* Ignore files in C:\Windows in CreateFileWHook.
* Catch the open if the file has a ppf associated with it. The patch has the name of the file with its extension swapped to .ppf.
* Patch the read in ReadFileHook.

* Implement copy and move for FlatPatch.