### PR TITLE
ppfinjector#30: Multi-process log

### DIFF
--- a/app/emulauncher/src/emulauncher.cpp
+++ b/app/emulauncher/src/emulauncher.cpp
@@ -53,7 +53,9 @@ namespace tdd::app::emulauncher {
 
 int main(int argc, char** argv)
 {
-   tdd::base::logging::InitSingleProcessLog();
+   tdd::base::logging::InitProcessLog(
+      tdd::base::logging::SharingMode::MultiProcess);
+
    if (argc > 1) {
       return tdd::app::emulauncher::cmd::HandleCmdLine(argc, argv);
    }

--- a/app/ppfinjector/src/ppfinjector.cpp
+++ b/app/ppfinjector/src/ppfinjector.cpp
@@ -3,8 +3,12 @@
 
 #include <ppftk/rom_patch/flat_patch.h>
 #include <ppftk/rom_patch/ppf/parser.h>
+
+#include <ppfbase/branding.h>
 #include <ppfbase/logging/logging.h>
 #include <ppfbase/filesystem/file.h>
+#include <ppfbase/filesystem/path_service.h>
+#include <ppfbase/process/this_module.h>
 
 #include <atomic>
 #include <filesystem>
@@ -287,6 +291,20 @@ namespace {
       DetourTransactionCommit();
    }
 }
+
+void InitLog()
+{
+   const auto logDir = base::fs::PathService::DllLogDirectory();
+   if (!logDir.has_value()) {
+      base::logging::InitDllLog();
+   }
+   else {
+      auto sharedLog = logDir.value() / TDD_EMU_LAUNCHER_EXE_W;
+      sharedLog.replace_extension(L".log");
+      base::logging::InitDllLog(sharedLog);
+   }
+}
+
 }
 
 BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID)
@@ -298,7 +316,7 @@ BOOL APIENTRY DllMain(HMODULE, DWORD reason, LPVOID)
     switch (reason)
     {
     case DLL_PROCESS_ATTACH:
-       tdd::base::logging::InitDllLog();
+       tdd::app::ppfinjector::InitLog();
        tdd::app::ppfinjector::InstallHooks();
        break;
     case DLL_PROCESS_DETACH:

--- a/base/ppfbase/inc/ppfbase/branding.h
+++ b/base/ppfbase/inc/ppfbase/branding.h
@@ -2,5 +2,8 @@
 
 #include <ppfbase/preprocessor_utils.h>
 
-#define TDD_PPF_INJECTOR_DLL_A       "ppfinjector.dll"
-#define TDD_PPF_INJECTOR_DLL_W       TDD_WIDEN(TDD_PPF_INJECTOR_DLL_A)
+#define TDD_EMU_LAUNCHER_EXE_A      "emulauncher.exe"
+#define TDD_EMU_LAUNCHER_EXE_W      TDD_WIDEN(TDD_EMU_LAUNCHER_EXE_A)
+
+#define TDD_PPF_INJECTOR_DLL_A      "ppfinjector.dll"
+#define TDD_PPF_INJECTOR_DLL_W      TDD_WIDEN(TDD_PPF_INJECTOR_DLL_A)

--- a/base/ppfbase/inc/ppfbase/logging/logging.h
+++ b/base/ppfbase/inc/ppfbase/logging/logging.h
@@ -5,11 +5,14 @@
 #include <ppfbase/logging/sharing_mode.h>
 #include <ppfbase/stdext/stream_operator.h>
 
+#include <filesystem>
+
 namespace tdd::base::logging {
 
-   void InitSingleProcessLog();
+   void InitProcessLog(SharingMode mode = SharingMode::MultiProcess);
 
-   void InitDllLog(SharingMode mode = SharingMode::SingleProcess);
+   void InitDllLog();
+   void InitDllLog(const std::filesystem::path& sharedLog);
 
    void SetMinLogLevel(Severity severity) noexcept;
    Severity GetMinLogLevel() noexcept;

--- a/base/ppfbase/inc/ppfbase/stdext/mutex.h
+++ b/base/ppfbase/inc/ppfbase/stdext/mutex.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <ppfbase/preprocessor_utils.h>
+
+#include <ppfbase/stdext/poor_mans_expected.h>
+
+#include <string>
+
+namespace tdd::stdext {
+   // Multi-process mutex
+   class [[nodiscard]] mp_mutex
+   {
+   public:
+      using native_handle_type = void*;
+
+      mp_mutex(std::wstring_view name);
+      mp_mutex(std::wstring&& name);
+      ~mp_mutex() noexcept;
+
+      TDD_DEFAULT_MOVE(mp_mutex);
+
+      void lock();
+      [[nodiscard]] bool try_lock();
+      void unlock();
+
+      [[nodiscard]] native_handle_type native_handle() const noexcept;
+
+      std::wstring_view name() const noexcept;
+
+   private:
+      std::wstring m_name;
+      native_handle_type m_hMutex;
+
+      TDD_DISABLE_COPY(mp_mutex);
+   };
+}

--- a/base/ppfbase/inc/ppfbase/stdext/system_error.h
+++ b/base/ppfbase/inc/ppfbase/stdext/system_error.h
@@ -7,4 +7,6 @@ namespace tdd::stdext {
    {
       return std::error_code(err, std::system_category());
    }
+
+   [[nodiscard]] std::error_code make_last_error() noexcept;
 }

--- a/base/ppfbase/ppfbase.vcxproj
+++ b/base/ppfbase/ppfbase.vcxproj
@@ -26,6 +26,7 @@
     <ClInclude Include="inc\ppfbase\process\this_module.h" />
     <ClInclude Include="inc\ppfbase\process\this_process.h" />
     <ClInclude Include="inc\ppfbase\stdext\iostream.h" />
+    <ClInclude Include="inc\ppfbase\stdext\mutex.h" />
     <ClInclude Include="inc\ppfbase\stdext\poor_mans_expected.h" />
     <ClInclude Include="inc\ppfbase\stdext\scope_exit.h" />
     <ClInclude Include="inc\ppfbase\stdext\stream_operator.h" />
@@ -33,6 +34,7 @@
     <ClInclude Include="inc\ppfbase\stdext\system_error.h" />
     <ClInclude Include="src\logging\basic_log.h" />
     <ClInclude Include="src\logging\logger.h" />
+    <ClInclude Include="src\logging\multi_process_log.h" />
     <ClInclude Include="src\logging\single_process_log.h" />
   </ItemGroup>
   <ItemGroup>
@@ -47,8 +49,10 @@
     <ClCompile Include="src\logging\severity.cpp" />
     <ClCompile Include="src\process\this_module.cpp" />
     <ClCompile Include="src\process\this_process.cpp" />
+    <ClCompile Include="src\stdext\mutex.cpp" />
     <ClCompile Include="src\stdext\stream_operator.cpp" />
     <ClCompile Include="src\stdext\string.cpp" />
+    <ClCompile Include="src\stdext\system_error.cpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/base/ppfbase/ppfbase.vcxproj.filters
+++ b/base/ppfbase/ppfbase.vcxproj.filters
@@ -116,6 +116,12 @@
     <ClInclude Include="inc\ppfbase\stdext\scope_exit.h">
       <Filter>PublicHeaders\stdext</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppfbase\stdext\mutex.h">
+      <Filter>PublicHeaders\stdext</Filter>
+    </ClInclude>
+    <ClInclude Include="src\logging\multi_process_log.h">
+      <Filter>Source\logging</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\process\this_process.cpp">
@@ -156,6 +162,12 @@
     </ClCompile>
     <ClCompile Include="src\filesystem\file.cpp">
       <Filter>Source\filesystem</Filter>
+    </ClCompile>
+    <ClCompile Include="src\stdext\mutex.cpp">
+      <Filter>Source\stdext</Filter>
+    </ClCompile>
+    <ClCompile Include="src\stdext\system_error.cpp">
+      <Filter>Source\stdext</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/base/ppfbase/src/logging/logger.h
+++ b/base/ppfbase/src/logging/logger.h
@@ -3,12 +3,14 @@
 #include <ppfbase/logging/severity.h>
 #include <ppfbase/logging/sharing_mode.h>
 
+#include <filesystem>
 
 namespace tdd::base::logging::details::Logger {
 
-   void InitSingleProcessLog();
+   void InitProcessLog(SharingMode shareMode);
 
-   void InitDllLog(SharingMode shareMode);
+   void InitDllLog();
+   void InitDllLog(const std::filesystem::path& sharedLog);
 
    void SetMinLogLevel(Severity severity) noexcept;
    Severity GetMinLogLevel() noexcept;

--- a/base/ppfbase/src/logging/logging.cpp
+++ b/base/ppfbase/src/logging/logging.cpp
@@ -4,14 +4,19 @@
 
 namespace tdd::base::logging {
 
-   void InitSingleProcessLog()
+   void InitProcessLog(SharingMode mode)
    {
-      details::Logger::InitSingleProcessLog();
+      details::Logger::InitProcessLog(mode);
    }
 
-   void InitDllLog(SharingMode mode)
+   void InitDllLog()
    {
-      details::Logger::InitDllLog(mode);
+      details::Logger::InitDllLog();
+   }
+
+   void InitDllLog(const std::filesystem::path& sharedLog)
+   {
+      details::Logger::InitDllLog(sharedLog);
    }
 
    void SetMinLogLevel(Severity severity) noexcept

--- a/base/ppfbase/src/logging/multi_process_log.h
+++ b/base/ppfbase/src/logging/multi_process_log.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "basic_log.h"
+
+#include <ppfbase/preprocessor_utils.h>
+#include <ppfbase/logging/ilog.h>
+#include <ppfbase/stdext/mutex.h>
+
+#include <mutex>
+
+namespace tdd::base::logging::details {
+
+   inline std::wstring GenerateLockName(const std::filesystem::path& logFile)
+   {
+      static constexpr auto kLockSuffix = L"-TddLogLock";
+      auto lockStem = logFile.stem().wstring();
+      lockStem.append(kLockSuffix);
+      return lockStem;
+   }
+
+   template <typename LogT>
+   class [[nodiscard]] MultiProcessDecorator final : public ILog
+   {
+   public:
+      MultiProcessDecorator(
+         const std::filesystem::path& filepath,
+         size_t maxBytesPerFile,
+         size_t numberOfFilesToKeep)
+         : m_lock(GenerateLockName(filepath))
+         , m_log(filepath, maxBytesPerFile, numberOfFilesToKeep)
+      {}
+
+      ~MultiProcessDecorator() override = default;
+
+      const std::filesystem::path& path() const noexcept override
+      {
+         return m_log.path();
+      }
+
+      void Write(const char* msg) override
+      {
+         std::lock_guard l(m_lock);
+         m_log.Write(msg);
+      }
+
+   private:
+      stdext::mp_mutex m_lock;
+      LogT m_log;
+
+      TDD_DISABLE_COPY_MOVE(MultiProcessDecorator);
+   };
+
+   using MultiProcessLog = MultiProcessDecorator<BasicLog>;
+
+}

--- a/base/ppfbase/src/stdext/mutex.cpp
+++ b/base/ppfbase/src/stdext/mutex.cpp
@@ -1,0 +1,62 @@
+#include <ppfbase/stdext/mutex.h>
+
+#include <ppfbase/diagnostics/assert.h>
+
+#include <Windows.h>
+
+namespace tdd::stdext {
+
+namespace {
+   [[nodiscard]] HANDLE MakeMutex(const wchar_t* name) noexcept
+   {
+      static constexpr LPSECURITY_ATTRIBUTES kDefaultSecurity = nullptr;
+      static constexpr BOOL kNotTakingOwnership = FALSE;
+
+      return ::CreateMutexW(kDefaultSecurity, kNotTakingOwnership, name);
+   }
+}
+
+mp_mutex::mp_mutex(std::wstring_view name)
+   : mp_mutex(std::wstring(name))
+{}
+
+mp_mutex::mp_mutex(std::wstring&& name)
+   : m_name(std::move(name))
+   , m_hMutex(MakeMutex(m_name.c_str()))
+{
+   if (NULL == m_hMutex) {
+      throw std::runtime_error(make_last_error().message());
+   }
+}
+
+mp_mutex::~mp_mutex() noexcept
+{
+   CloseHandle(m_hMutex);
+}
+
+void mp_mutex::lock()
+{
+   ::WaitForSingleObject(m_hMutex, INFINITE);
+}
+
+bool mp_mutex::try_lock()
+{
+   return WAIT_OBJECT_0 == ::WaitForSingleObject(m_hMutex, 0);
+}
+
+void mp_mutex::unlock()
+{
+   TDD_ASSERT(::ReleaseMutex(m_hMutex));
+}
+
+mp_mutex::native_handle_type mp_mutex::native_handle() const noexcept
+{
+   return m_hMutex;
+}
+
+std::wstring_view mp_mutex::name() const noexcept
+{
+   return m_name;
+}
+
+}

--- a/base/ppfbase/src/stdext/system_error.cpp
+++ b/base/ppfbase/src/stdext/system_error.cpp
@@ -1,0 +1,12 @@
+#include <ppfbase/stdext/system_error.h>
+
+#include <Windows.h>
+
+namespace tdd::stdext {
+
+std::error_code make_last_error() noexcept
+{
+   return make_win32_ec(::GetLastError());
+}
+
+}


### PR DESCRIPTION
* Add mp_mutex to stdext.
* Add make_last_error.

* Add MultiProcessLog.
* Change the log initialization functions to allow for multiprocess logging to the same file.
* Use multiprocess log in emulauncher.exe and ppfinjector.dll.