### PR TITLE
ppfinjector#29: Configuration

### DIFF
--- a/app/emulauncher/emulauncher.vcxproj
+++ b/app/emulauncher/emulauncher.vcxproj
@@ -85,6 +85,12 @@
     <ProjectReference Include="..\..\deps\detours\detours\detours.vcxproj">
       <Project>{3b717b2a-edb5-42a0-ade7-c361629ffe22}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\deps\jsoncpp\jsoncpp.vcxproj">
+      <Project>{176b146f-79ee-4840-b5c3-cac17e02f80a}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\tk\ppftk\ppftk.vcxproj">
+      <Project>{5561b3c1-3815-4992-9848-dcc234db7539}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\cmds\cli.h" />

--- a/app/emulauncher/src/cmds/test/live_patch.cpp
+++ b/app/emulauncher/src/cmds/test/live_patch.cpp
@@ -1,5 +1,7 @@
 #include "live_patch.h"
 
+#include <ppftk/rom_patch/patch_file_exts.h>
+
 #include <ppfbase/branding.h>
 #include <ppfbase/logging/logging.h>
 #include <ppfbase/process/this_process.h>
@@ -84,7 +86,7 @@ void LivePatch::VerifyPaths()
 
    {
       auto ppf = origCano;
-      ppf.replace_extension(".ppf");
+      ppf.replace_extension(tk::rompatch::exts::kPpf);
 
       if (!fs::exists(ppf)) {
          throw std::runtime_error("PPF not found for " + origCano.string());

--- a/app/ppfinjector/ppfinjector.vcxproj
+++ b/app/ppfinjector/ppfinjector.vcxproj
@@ -83,6 +83,9 @@
     <ProjectReference Include="..\..\deps\detours\detours\detours.vcxproj">
       <Project>{3b717b2a-edb5-42a0-ade7-c361629ffe22}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\deps\jsoncpp\jsoncpp.vcxproj">
+      <Project>{176b146f-79ee-4840-b5c3-cac17e02f80a}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\tk\ppftk\ppftk.vcxproj">
       <Project>{5561b3c1-3815-4992-9848-dcc234db7539}</Project>
     </ProjectReference>

--- a/app/ppfinjector/src/read_ops_log.cpp
+++ b/app/ppfinjector/src/read_ops_log.cpp
@@ -27,7 +27,7 @@ ReadOpsLog::ReadOpsLog(HANDLE hFile, const std::filesystem::path& targetFile)
    std::wostringstream logFileName;
    logFileName << base::process::ThisProcess::Name().stem().wstring() << "."
       << ::GetCurrentProcessId() << "."
-      << targetFile.filename().wstring() << ".writeops.log";
+      << targetFile.filename().wstring() << ".readops.log";
 
    const auto logPath = logDir.value() / logFileName.str();
    m_log.exceptions(kNoException);

--- a/tk/ppftk/inc/ppftk/config/app.h
+++ b/tk/ppftk/inc/ppftk/config/app.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <ppfbase/preprocessor_utils.h>
+#include <ppfbase/logging/severity.h>
+
+#include <filesystem>
+#include <set>
+#include <string>
+
+namespace tdd::tk::config::App {
+
+   const base::logging::Severity LogLevel() noexcept;
+
+   const std::filesystem::path& Emulator() noexcept;
+   void Emulator(const std::filesystem::path& emulator);
+   void ClearEmulator();
+
+   const std::set<std::string>& TargetExts() noexcept;
+
+
+}

--- a/tk/ppftk/inc/ppftk/config/patch.h
+++ b/tk/ppftk/inc/ppftk/config/patch.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <ppfbase/preprocessor_utils.h>
+
+#include <filesystem>
+
+namespace tdd::tk::config {
+
+   class [[nodiscard]] Patch
+   {
+   public:
+      Patch(const std::filesystem::path& target);
+      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Patch);
+
+      [[nodiscard]] const std::filesystem::path& PatchFile() const noexcept;
+      [[nodiscard]] bool CalculateEdc() const noexcept;
+
+   private:
+      std::filesystem::path m_patch;
+      bool m_calculateEdc;
+   };
+
+}

--- a/tk/ppftk/inc/ppftk/rom_patch/patch_file_exts.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patch_file_exts.h
@@ -1,0 +1,6 @@
+#pragma once
+
+
+namespace tdd::tk::rompatch::exts {
+   inline constexpr auto kPpf = L".ppf";
+}

--- a/tk/ppftk/ppftk.vcxproj
+++ b/tk/ppftk/ppftk.vcxproj
@@ -11,15 +11,22 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="inc\ppftk\config\app.h" />
+    <ClInclude Include="inc\ppftk\config\patch.h" />
     <ClInclude Include="inc\ppftk\rom_patch\flat_patch.h" />
     <ClInclude Include="inc\ppftk\rom_patch\patch_descriptor.h" />
+    <ClInclude Include="inc\ppftk\rom_patch\patch_file_exts.h" />
     <ClInclude Include="inc\ppftk\rom_patch\patch_item.h" />
     <ClInclude Include="inc\ppftk\rom_patch\ppf\parser.h" />
     <ClInclude Include="inc\ppftk\rom_patch\ppf\ppf3.h" />
+    <ClInclude Include="src\config\app_impl.h" />
     <ClInclude Include="src\rom_patch\ppf\schema.h" />
     <ClInclude Include="src\rom_patch\ppf\v3.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="src\config\app.cpp" />
+    <ClCompile Include="src\config\app_impl.cpp" />
+    <ClCompile Include="src\config\patch.cpp" />
     <ClCompile Include="src\rom_patch\flat_patch.cpp" />
     <ClCompile Include="src\rom_patch\patch_descriptor.cpp" />
     <ClCompile Include="src\rom_patch\ppf\parser.cpp" />

--- a/tk/ppftk/ppftk.vcxproj.filters
+++ b/tk/ppftk/ppftk.vcxproj.filters
@@ -21,6 +21,12 @@
     <Filter Include="Source\rom_patch\ppf">
       <UniqueIdentifier>{1621f1ac-5d08-49b7-b334-9d407dd42072}</UniqueIdentifier>
     </Filter>
+    <Filter Include="PublicHeaders\config">
+      <UniqueIdentifier>{0f0ba855-d1af-4805-a763-0a7899604e14}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\config">
+      <UniqueIdentifier>{76927b45-7aae-42cf-a069-397b909c146a}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\ppftk\rom_patch\ppf\parser.h">
@@ -44,6 +50,18 @@
     <ClInclude Include="inc\ppftk\rom_patch\ppf\ppf3.h">
       <Filter>PublicHeaders\rom_patch\ppf</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppftk\config\app.h">
+      <Filter>PublicHeaders\config</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ppftk\config\patch.h">
+      <Filter>PublicHeaders\config</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ppftk\rom_patch\patch_file_exts.h">
+      <Filter>PublicHeaders\rom_patch</Filter>
+    </ClInclude>
+    <ClInclude Include="src\config\app_impl.h">
+      <Filter>Source\config</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\rom_patch\flat_patch.cpp">
@@ -60,6 +78,15 @@
     </ClCompile>
     <ClCompile Include="src\rom_patch\ppf\ppf3.cpp">
       <Filter>Source\rom_patch\ppf</Filter>
+    </ClCompile>
+    <ClCompile Include="src\config\app_impl.cpp">
+      <Filter>Source\config</Filter>
+    </ClCompile>
+    <ClCompile Include="src\config\patch.cpp">
+      <Filter>Source\config</Filter>
+    </ClCompile>
+    <ClCompile Include="src\config\app.cpp">
+      <Filter>Source\config</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/tk/ppftk/src/config/app.cpp
+++ b/tk/ppftk/src/config/app.cpp
@@ -1,0 +1,40 @@
+#include <ppftk/config/app.h>
+
+#include "app_impl.h"
+
+
+namespace tdd::tk::config::App {
+
+namespace {
+   details::AppImpl& GetInstance() {
+      static details::AppImpl config;
+      return config;
+   }
+}
+
+const base::logging::Severity LogLevel() noexcept
+{
+   return GetInstance().LogLevel();
+}
+
+const std::filesystem::path& Emulator() noexcept
+{
+   return GetInstance().Emulator();
+}
+
+void Emulator(const std::filesystem::path& emulator)
+{
+   GetInstance().Emulator(emulator);
+}
+
+void ClearEmulator()
+{
+   GetInstance().ClearEmulator();
+}
+
+const std::set<std::string>& TargetExts() noexcept
+{
+   return GetInstance().TargetExts();
+}
+
+}

--- a/tk/ppftk/src/config/app_impl.cpp
+++ b/tk/ppftk/src/config/app_impl.cpp
@@ -1,0 +1,182 @@
+#include "app_impl.h"
+
+#include <ppfbase/logging/logging.h>
+#include <ppfbase/process/this_module.h>
+#include <ppfbase/process/this_process.h>
+#include <ppfbase/stdext/string.h>
+
+#include <json/json.h>
+
+#include <fstream>
+
+namespace tdd::tk::config::details {
+
+namespace {
+   namespace fs = std::filesystem;
+
+   namespace schema {
+      static constexpr auto kConfigFileName = L"ppfinjector.json";
+      static const std::set<std::string> kDefaultExts{
+         ".bin"
+      };
+
+      // fs::path. Absolute path.
+      static constexpr auto kEmulator = "emulator";
+      // int.
+      static constexpr auto kLogLevel = "log_level";
+      // array of strings
+      static constexpr auto kTargetExts = "target_extensions";
+   }
+
+   [[nodiscard]] fs::path ConfigPath()
+   {
+      // This is equivalent to ThisProcess::ImagePath() when the calling
+      // module is the exe.
+      const auto dllPath = base::process::ThisModule::ImagePath();
+
+      return dllPath.parent_path() / schema::kConfigFileName;
+   }
+
+   [[nodiscard]] bool WriterIsExe()
+   {
+      const auto exePath = base::process::ThisProcess::ImagePath();
+      const auto dllPath = base::process::ThisModule::ImagePath();
+
+      TDD_DCHECK(
+         exePath == dllPath,
+         "Only the launcher process should writing the config file");
+
+      return exePath == dllPath;
+   }
+
+   Json::Value ToJson(const AppImpl& config)
+   {
+      Json::Value exts(Json::arrayValue);
+      for (const auto& e : config.TargetExts()) {
+         exts.append(e);
+      }
+
+      Json::Value json;
+      if (!config.Emulator().empty()) {
+         json[schema::kEmulator] = stdext::WideToUtf8(config.Emulator().wstring());
+      }
+
+      json[schema::kLogLevel] = static_cast<int>(config.LogLevel());
+      json[schema::kTargetExts] = exts;
+      return json;
+   }
+
+   void WriteConfig(const AppImpl& config)
+   {
+      if (!WriterIsExe()) {
+         return;
+      }
+
+      std::ofstream out(ConfigPath(), std::ios::trunc);
+
+      Json::StreamWriterBuilder writer;
+      writer["indentation"] = "  ";
+      out << Json::writeString(writer, ToJson(config)) << std::endl;
+      out.close();
+   }
+
+   Json::Value ParseConfig()
+   {
+      const auto configPath = ConfigPath();
+      if (!fs::exists(configPath)) {
+         return Json::nullValue;
+      }
+
+      std::ifstream in(configPath);
+
+      Json::Value config;
+      Json::CharReaderBuilder builder;
+      std::string errs;
+      if (!Json::parseFromStream(builder, in, &config, &errs)) {
+         TDD_LOG_ERROR() << "Unable to parse [" << configPath.wstring() << "]: "
+            << errs;
+         return Json::nullValue;
+      }
+
+      return config;
+   }
+}
+
+AppImpl::AppImpl()
+   : m_emulator()
+   , m_targetExts(schema::kDefaultExts)
+   , m_logLevel(base::logging::Severity::Info)
+{
+   try {
+      Load();
+   }
+   catch (const std::exception& e) {
+      TDD_LOG_ERROR() << "Unable to load config: " << e.what();
+   }
+}
+
+const base::logging::Severity AppImpl::LogLevel() const noexcept
+{
+   return m_logLevel;
+}
+
+const std::filesystem::path& AppImpl::Emulator() const noexcept
+{
+   return m_emulator;
+}
+
+void AppImpl::Emulator(const std::filesystem::path& emulator)
+{
+   TDD_CHECK(emulator.is_absolute(), "Emulator path should be absolute");
+   m_emulator = emulator;
+   WriteConfig(*this);
+}
+
+void AppImpl::ClearEmulator()
+{
+   m_emulator.clear();
+   WriteConfig(*this);
+}
+
+const std::set<std::string>& AppImpl::TargetExts() const noexcept
+{
+   return m_targetExts;
+}
+
+void AppImpl::Load()
+{
+   const auto config = ParseConfig();
+   if (config.isNull()) {
+      return;
+   }
+
+   const auto emulator = config.get(schema::kEmulator, "").asString();
+   if (!emulator.empty()) {
+      fs::path emuPath(stdext::Utf8ToWide(emulator));
+      if (emuPath.is_absolute() && emuPath.extension() == L".exe") {
+         m_emulator = std::move(emuPath);
+      }
+      else {
+         TDD_LOG_ERROR() << "Invalid emulator path: [" << emuPath << "]";
+      }
+   }
+
+   if (config.isMember(schema::kLogLevel)) {
+      m_logLevel = static_cast<base::logging::Severity>(
+         config[schema::kLogLevel].asInt());
+   }
+
+   if (config.isMember(schema::kTargetExts)) {
+      const auto extsArray = config[schema::kTargetExts];
+      for (const auto& item : extsArray) {
+         auto ext = item.asString();
+         if (ext.starts_with(".")) {
+            m_targetExts.insert(std::move(ext));
+         }
+      }
+   }
+}
+
+
+
+}

--- a/tk/ppftk/src/config/app_impl.h
+++ b/tk/ppftk/src/config/app_impl.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <ppfbase/preprocessor_utils.h>
+#include <ppfbase/logging/severity.h>
+
+#include <filesystem>
+#include <set>
+#include <string>
+
+namespace tdd::tk::config::details {
+
+   class [[nodiscard]] AppImpl
+   {
+   public:
+      AppImpl();
+      ~AppImpl() = default;
+      TDD_DEFAULT_COPY_MOVE(AppImpl);
+
+      const base::logging::Severity LogLevel() const noexcept;
+
+      const std::filesystem::path& Emulator() const noexcept;
+      void Emulator(const std::filesystem::path& emulator);
+      void ClearEmulator();
+
+      const std::set<std::string>& TargetExts() const noexcept;
+
+   private:
+      void Load();
+
+      std::filesystem::path m_emulator;
+      std::set<std::string> m_targetExts;
+      base::logging::Severity m_logLevel;
+   };
+
+}

--- a/tk/ppftk/src/config/patch.cpp
+++ b/tk/ppftk/src/config/patch.cpp
@@ -1,0 +1,116 @@
+#include <ppftk/config/patch.h>
+
+#include <ppftk/rom_patch/patch_file_exts.h>
+
+#include <ppfbase/logging/logging.h>
+#include <ppfbase/stdext/poor_mans_expected.h>
+
+#include <json/json.h>
+
+#include <fstream>
+
+#include <Windows.h>
+
+namespace tdd::tk::config {
+
+namespace {
+   namespace fs = std::filesystem;
+
+   namespace schema {
+      constexpr auto kPatch = "patch";
+      constexpr auto kCalculateEdc = "calculate_edc";
+   }
+
+   stdext::pm_expected<Json::Value> ParseConfig(
+      const std::filesystem::path& config)
+   {
+      if (!fs::exists(config)) {
+         return stdext::make_win32_ec(ERROR_FILE_NOT_FOUND);
+      }
+
+      std::ifstream configStream(config);
+
+      Json::Value confJson;
+      Json::CharReaderBuilder builder;
+      std::string errs;
+      if (!Json::parseFromStream(builder, configStream, &confJson, &errs)) {
+         TDD_LOG_WARN() << "Unable to parse: [" << config.wstring() << "]: "
+            << errs;
+         return stdext::make_win32_ec(ERROR_FILE_NOT_SUPPORTED);
+      }
+
+      if (!confJson.isMember(schema::kPatch)) {
+         TDD_LOG_WARN() << "Missing [" << schema::kPatch << "]";
+         return stdext::make_win32_ec(ERROR_INVALID_PARAMETER);
+      }
+
+      return std::move(confJson);
+   }
+
+   std::tuple<fs::path, bool> ParseConfig(
+      const fs::path& target,
+      const Json::Value& json)
+   {
+      fs::path patchFile(json.get(schema::kPatch, {}).asString());
+      if (patchFile.empty()) {
+         TDD_LOG_WARN() << "Invalid patch path: [" << patchFile.wstring() << "]";
+         return {};
+      }
+
+      if (patchFile.is_relative()) {
+         patchFile = target.parent_path() / patchFile;
+      }
+
+      std::error_code ec;
+      patchFile = fs::canonical(patchFile, ec);
+      if (ec) {
+         TDD_LOG_WARN() << "Error locating patch file [" << patchFile.wstring()
+            << "]: " << ec.message();
+         return {};
+      }
+
+      const auto calculateEdc = json.get(schema::kCalculateEdc, false).asBool();
+      return {std::move(patchFile), calculateEdc};
+   }
+
+   std::tuple<fs::path, bool> BuildConfig(const fs::path& target)
+   {
+      static constexpr auto kConfigExt = L".piconf";
+
+      auto configPath = target;
+      configPath.replace_extension(kConfigExt);
+      const auto config = ParseConfig(configPath);
+
+      if (config.has_value()) {
+         return ParseConfig(target, config.value());
+      }
+
+      auto ppfPath = target;
+      ppfPath.replace_extension(rompatch::exts::kPpf);
+      if (!fs::exists(ppfPath)) {
+         return {};
+      }
+
+      return {std::move(ppfPath), true};
+   }
+}
+
+Patch::Patch(const std::filesystem::path& target)
+   : m_patch()
+   , m_calculateEdc(true)
+{
+   std::tie(m_patch, m_calculateEdc) = BuildConfig(target);
+}
+
+const std::filesystem::path& Patch::PatchFile() const noexcept
+{
+   return m_patch;
+}
+
+bool Patch::CalculateEdc() const noexcept
+{
+   return m_calculateEdc;
+}
+
+
+}


### PR DESCRIPTION
* Add patch_file_exts.h as a place to keep all the patch file extensions.
* Add config::App for application configuration.
* Add config::Patch for holding configurations for specific target files.
* Use the new config objects in emulauncher and ppfinjector.