### PR TITLE
ppfinjector#43: Add SectorRange

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,8 @@
 ﻿---
-AccessModifierOffset: '0'
+AccessModifierOffset: '-3'
 AlignAfterOpenBracket: AlwaysBreak
 AlignConsecutiveMacros: 'true'
-AlignConsecutiveAssignments: 'true'
+AlignConsecutiveAssignments: 'false'
 AlignConsecutiveDeclarations: 'false'
 AlignEscapedNewlines: Right
 AlignOperands: 'false'

--- a/ppfinjector.sln
+++ b/ppfinjector.sln
@@ -36,6 +36,13 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "detours", "deps\detours\det
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ppftk_test", "tk\ppftk\ppftk_test.vcxproj", "{0CCB3C35-4FDD-40DE-9B02-8734CD5E8426}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "0-aux", "0-aux", "{FD605332-7834-41A3-83A9-C99842FB6358}"
+	ProjectSection(SolutionItems) = preProject
+		.clang-format = .clang-format
+		LICENSE = LICENSE
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/sector_range.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/sector_range.h
@@ -1,0 +1,166 @@
+#pragma once
+
+#include <ppfbase/preprocessor_utils.h>
+
+#include <compare>
+#include <iterator>
+#include <span>
+
+namespace tdd::tk::rompatch::cd {
+
+namespace spec {
+   struct [[nodiscard]] Sector;
+}
+
+class [[nodiscard]] SectorRange
+{
+public:
+   struct SectorView
+   {
+      uint64_t number;
+      std::span<uint8_t> data;
+
+      [[nodiscard]] bool IsComplete() const noexcept;
+      spec::Sector* AsSector() const noexcept;
+   };
+
+   using value_type      = SectorView;
+   using pointer         = value_type*;
+   using const_pointer   = const value_type*;
+   using reference       = value_type&;
+   using const_reference = const value_type&;
+   using size_type       = size_t;
+   using difference_type = ptrdiff_t;
+
+   class ConstIterator
+   {
+   public:
+      using iterator_concept  = std::random_access_iterator_tag;
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type        = SectorRange::value_type;
+      using difference_type   = SectorRange::difference_type;
+      using pointer           = SectorRange::const_pointer;
+      using reference         = SectorRange::const_reference;
+
+      ConstIterator() noexcept;
+      ~ConstIterator() = default;
+      TDD_DEFAULT_COPY_MOVE(ConstIterator);
+
+      [[nodiscard]] reference operator*() const noexcept;
+      [[nodiscard]] pointer operator->() const noexcept;
+
+      ConstIterator& operator++() noexcept;
+      ConstIterator operator++(int) noexcept;
+      ConstIterator& operator--() noexcept;
+      ConstIterator operator--(int) noexcept;
+
+      ConstIterator& operator+=(const difference_type offset) noexcept;
+      [[nodiscard]] ConstIterator
+      operator+(const difference_type offset) const noexcept;
+
+      ConstIterator& operator-=(const difference_type offset) noexcept;
+      [[nodiscard]] ConstIterator
+      operator-(const difference_type offset) const noexcept;
+
+      [[nodiscard]] difference_type
+      operator-(const ConstIterator& rhs) const noexcept;
+
+      [[nodiscard]] reference
+      operator[](const difference_type offset) const noexcept;
+
+      [[nodiscard]] bool operator==(const ConstIterator& other) const noexcept;
+
+      [[nodiscard]] std::strong_ordering
+      operator<=>(const ConstIterator& rhs) const noexcept;
+
+   private:
+      friend class SectorRange;
+      ConstIterator(
+         const uint64_t sectorAddr,
+         const uint64_t rangeAddr,
+         std::span<uint8_t> range) noexcept;
+
+      void CheckCompatible(const ConstIterator& other) const noexcept;
+
+      SectorView m_sector;
+      uint64_t m_rangeStart;
+      uint64_t m_rangeEnd;
+      std::span<uint8_t> m_range;
+   };
+
+   class Iterator : public ConstIterator
+   {
+   public:
+      using Base = ConstIterator;
+
+      using iterator_concept  = std::random_access_iterator_tag;
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type        = SectorRange::value_type;
+      using difference_type   = SectorRange::difference_type;
+      using pointer           = SectorRange::pointer;
+      using reference         = SectorRange::reference;
+
+      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Iterator);
+
+      [[nodiscard]] reference operator*() const noexcept;
+      [[nodiscard]] pointer operator->() const noexcept;
+
+      Iterator& operator++() noexcept;
+      Iterator operator++(int) noexcept;
+      Iterator& operator--() noexcept;
+      Iterator operator--(int) noexcept;
+
+      Iterator& operator+=(const difference_type offset) noexcept;
+      [[nodiscard]] Iterator operator+(const difference_type offset) noexcept;
+
+      Iterator& operator-=(const difference_type offset) noexcept;
+
+      // iterator diff.
+      using Base::operator-;
+
+      [[nodiscard]] Iterator operator-(const difference_type offset) noexcept;
+      [[nodiscard]] reference
+      operator[](const difference_type offset) const noexcept;
+
+   private:
+      friend class SectorRange;
+      Iterator(
+         const uint64_t sectorAddr,
+         const uint64_t rangeAddr,
+         std::span<uint8_t> range) noexcept;
+
+      Iterator(const ConstIterator& other);
+   };
+
+   using iterator       = Iterator;
+   using const_iterator = ConstIterator;
+
+   SectorRange() noexcept;
+   SectorRange(const uint64_t addr, std::span<uint8_t> data) noexcept;
+
+   ~SectorRange() = default;
+   TDD_DEFAULT_COPY_MOVE(SectorRange);
+
+   iterator begin() noexcept;
+   const_iterator begin() const noexcept;
+   const_iterator cbegin() const noexcept;
+
+   iterator end() noexcept;
+   const_iterator end() const noexcept;
+   const_iterator cend() const noexcept;
+
+   [[nodiscard]] bool empty() const noexcept;
+   [[nodiscard]] size_type size() const noexcept;
+
+   reference front() noexcept;
+   const_reference front() const noexcept;
+
+   reference back() noexcept;
+   const_reference back() const noexcept;
+
+private:
+   uint64_t m_addr;
+   std::span<uint8_t> m_data;
+};
+
+}

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/spec.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/spec.h
@@ -4,124 +4,123 @@
 
 namespace tdd::tk::rompatch::cd::spec {
 
-   // ECMA-130, 14
-   inline constexpr size_t kSectorSize = 2352;
+// ECMA-130, 14
+inline constexpr size_t kSectorSize = 2352;
 
-   // 14.1
-   inline constexpr std::array<uint8_t, 12> kSync = {
-      00, 0xff, 0xff, 0xff, 0xff, 0xff,
-      0xff, 0xff, 0xff, 0xff, 0xff, 00 };
+// 14.1
+inline constexpr std::array<uint8_t, 12> kSync =
+   {00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 00};
 
 #pragma pack(push, 1)
-   // 14
-   union [[nodiscard]] SectorHeader
+// 14
+union [[nodiscard]] SectorHeader
+{
+   struct
    {
-      struct
-      {
-         // Sector address
-         uint8_t minutes;
-         uint8_t seconds;
-         uint8_t frame;
-         // Sector mode
-         uint8_t mode;
-      };
-      uint32_t full;
-   };
+      // Sector address
+      uint8_t minutes;
+      uint8_t seconds;
+      uint8_t frame;
+      // Sector mode
+      uint8_t mode;
+   } parts;
+   uint32_t full;
+};
 
-   inline constexpr size_t kSectorHeaderSize = 4;
-   static_assert(sizeof(SectorHeader) == kSectorHeaderSize);
+inline constexpr size_t kSectorHeaderSize = 4;
+static_assert(sizeof(SectorHeader) == kSectorHeaderSize);
 
-   // 14
-   struct [[nodiscard]] Mode0Data
+// 14
+struct [[nodiscard]] Mode0Data
+{
+   uint8_t zeros[2336];
+};
+
+// 14
+struct [[nodiscard]] Mode1Data
+{
+   uint8_t userData[2048];
+   uint8_t edc[4];
+   // 8 bytes of '0'
+   uint8_t intermediate[8];
+   uint8_t pParity[172];
+   uint8_t qParity[104];
+};
+
+// 14
+struct [[nodiscard]] Mode2Data
+{
+   uint8_t userData[2336];
+};
+
+// CD-ROM XA: 4.3.2.3
+struct [[nodiscard]] XaSubmode
+{
+   uint8_t endOfFile : 1;
+   uint8_t realTimeSector : 1;
+   uint8_t form : 1;
+   uint8_t trigger : 1;
+   uint8_t data : 1;
+   uint8_t audio : 1;
+   uint8_t video : 1;
+   uint8_t endOfRecord : 1;
+};
+
+// CD-ROM XA: 4.3.1
+union [[nodiscard]] XaSubHeader
+{
+   struct
    {
-      uint8_t zeros[2336];
-   };
+      uint8_t fileNumber;
+      uint8_t channel;
+      XaSubmode submode;
+      uint8_t codingInfo;
+   } parts;
+   uint32_t full;
+};
 
-   // 14
-   struct [[nodiscard]] Mode1Data
+// CD-ROM XA: 4.5.1
+struct [[nodiscard]] Mode2Xa1Data
+{
+   uint8_t data[2048];
+   uint8_t edc[4];
+   uint8_t pParity[172];
+   uint8_t qParity[104];
+};
+
+// CD-ROM XA: 4.6.1
+struct [[nodiscard]] Mode2Xa2Data
+{
+   uint8_t data[2324];
+   // CRC-32 or 0
+   uint8_t edc[4];
+};
+
+struct [[nodiscard]] Mode2XaData
+{
+   XaSubHeader subheader[2];
+   union
    {
-      uint8_t userData[2048];
-      uint8_t edc[4];
-      // 8 bytes of '0'
-      uint8_t intermediate[8];
-      uint8_t pParity[172];
-      uint8_t qParity[104];
+      Mode2Xa1Data form1;
+      Mode2Xa2Data form2;
    };
+};
 
-   // 14
-   struct [[nodiscard]] Mode2Data
+struct [[nodiscard]] Sector
+{
+   uint8_t sync[12];
+   SectorHeader header;
+   // data portion
+   union
    {
-      uint8_t userData[2336];
+      Mode0Data mode0;
+      Mode1Data mode1;
+      Mode2Data mode2;
+      Mode2XaData xa;
    };
+};
 
-   // CD-ROM XA: 4.3.2.3
-   struct [[nodiscard]] XaSubmode
-   {
-      uint8_t endOfFile : 1;
-      uint8_t realTimeSector : 1;
-      uint8_t form : 1;
-      uint8_t trigger : 1;
-      uint8_t data : 1;
-      uint8_t audio : 1;
-      uint8_t video : 1;
-      uint8_t endOfRecord : 1;
-   };
-
-   // CD-ROM XA: 4.3.1
-   union [[nodiscard]] XaSubHeader
-   {
-      struct // parts
-      {
-         uint8_t fileNumber;
-         uint8_t channel;
-         XaSubmode submode;
-         uint8_t codingInfo;
-      };
-      uint32_t full;
-   };
-
-   // CD-ROM XA: 4.5.1
-   struct [[nodiscard]] Mode2Xa1Data
-   {
-      uint8_t data[2048];
-      uint8_t edc[4];
-      uint8_t pParity[172];
-      uint8_t qParity[104];
-   };
-
-   // CD-ROM XA: 4.6.1
-   struct [[nodiscard]] Mode2Xa2Data
-   {
-      uint8_t data[2324];
-      // CRC-32 or 0
-      uint8_t edc[4];
-   };
-
-   struct [[nodiscard]] Mode2XaData
-   {
-      XaSubHeader subheader[2];
-      union
-      {
-         Mode2Xa1Data form1;
-         Mode2Xa2Data form2;
-      };
-   };
-
-   struct [[nodiscard]] Sector
-   {
-      uint8_t sync[12];
-      SectorHeader header;
-      // data portion
-      union
-      {
-         Mode0Data mode0;
-         Mode1Data mode1;
-         Mode2Data mode2;
-         Mode2XaData xa;
-      };
-   };
-
-   static_assert(sizeof(Sector) == kSectorSize);
+static_assert(sizeof(Sector) == kSectorSize);
 #pragma pack(pop)
 
 }

--- a/tk/ppftk/ppftk.vcxproj
+++ b/tk/ppftk/ppftk.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClInclude Include="inc\ppftk\config\app.h" />
     <ClInclude Include="inc\ppftk\config\patch.h" />
+    <ClInclude Include="inc\ppftk\rom_patch\cd\sector_range.h" />
     <ClInclude Include="inc\ppftk\rom_patch\cd\spec.h" />
     <ClInclude Include="inc\ppftk\rom_patch\flat_patch.h" />
     <ClInclude Include="inc\ppftk\rom_patch\ipatcher.h" />
@@ -31,6 +32,7 @@
     <ClCompile Include="src\config\app.cpp" />
     <ClCompile Include="src\config\app_impl.cpp" />
     <ClCompile Include="src\config\patch.cpp" />
+    <ClCompile Include="src\rom_patch\cd\sector_range.cpp" />
     <ClCompile Include="src\rom_patch\flat_patch.cpp" />
     <ClCompile Include="src\rom_patch\patch_descriptor.cpp" />
     <ClCompile Include="src\rom_patch\ppf\parser.cpp" />

--- a/tk/ppftk/ppftk.vcxproj.filters
+++ b/tk/ppftk/ppftk.vcxproj.filters
@@ -30,6 +30,9 @@
     <Filter Include="PublicHeaders\rom_patch\cd">
       <UniqueIdentifier>{2ef0bf40-7468-445d-a223-df89f9adbf55}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source\rom_patch\cd">
+      <UniqueIdentifier>{97b91867-b020-429a-ad2e-0ffb6a33d0b3}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="inc\ppftk\rom_patch\ppf\parser.h">
@@ -77,6 +80,9 @@
     <ClInclude Include="inc\ppftk\rom_patch\cd\spec.h">
       <Filter>PublicHeaders\rom_patch\cd</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppftk\rom_patch\cd\sector_range.h">
+      <Filter>PublicHeaders\rom_patch\cd</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="src\rom_patch\flat_patch.cpp">
@@ -105,6 +111,9 @@
     </ClCompile>
     <ClCompile Include="src\rom_patch\simple_patcher.cpp">
       <Filter>Source\rom_patch</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rom_patch\cd\sector_range.cpp">
+      <Filter>Source\rom_patch\cd</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/tk/ppftk/ppftk_test.vcxproj
+++ b/tk/ppftk/ppftk_test.vcxproj
@@ -76,6 +76,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="test\ppftk_test.cpp" />
+    <ClCompile Include="test\rom_patch\cd\sector_range_test.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\base\ppfbase\ppfbase.vcxproj">

--- a/tk/ppftk/ppftk_test.vcxproj.filters
+++ b/tk/ppftk/ppftk_test.vcxproj.filters
@@ -5,10 +5,19 @@
       <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
       <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
     </Filter>
+    <Filter Include="Tests\rom_patch">
+      <UniqueIdentifier>{5d870390-ce77-4c76-b5f3-b7ca4adfaed0}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Tests\rom_patch\cd">
+      <UniqueIdentifier>{a4a17e06-d6e6-42f4-b446-635e2977f492}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="test\ppftk_test.cpp">
       <Filter>Tests</Filter>
+    </ClCompile>
+    <ClCompile Include="test\rom_patch\cd\sector_range_test.cpp">
+      <Filter>Tests\rom_patch\cd</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/tk/ppftk/src/rom_patch/cd/sector_range.cpp
+++ b/tk/ppftk/src/rom_patch/cd/sector_range.cpp
@@ -1,0 +1,396 @@
+#include <ppftk/rom_patch/cd/sector_range.h>
+
+#include <ppftk/rom_patch/cd/spec.h>
+
+#include <ppfbase/logging/logging.h>
+
+namespace tdd::tk::rompatch::cd {
+
+namespace {
+   [[nodiscard]] uint64_t StartSector(const uint64_t startAddr)
+   {
+      return startAddr / spec::kSectorSize;
+   }
+
+   [[nodiscard]] uint64_t EndSector(const uint64_t endAddr)
+   {
+      // Add 1 if ends in the middle of a sector.
+      return endAddr / spec::kSectorSize + !!(endAddr % spec::kSectorSize);
+   }
+}
+
+bool SectorRange::SectorView::IsComplete() const noexcept
+{
+   return data.size_bytes() == spec::kSectorSize;
+}
+
+spec::Sector* SectorRange::SectorView::AsSector() const noexcept
+{
+   TDD_DCHECK(data.size_bytes() == spec::kSectorSize, "Incomplete sector");
+
+   return reinterpret_cast<spec::Sector*>(data.data());
+}
+
+SectorRange::ConstIterator::ConstIterator() noexcept
+   : m_sector{0}
+   , m_rangeStart(0)
+   , m_rangeEnd(0)
+   , m_range()
+{}
+
+SectorRange::ConstIterator::reference
+SectorRange::ConstIterator::operator*() const noexcept
+{
+   return *(operator->());
+}
+
+SectorRange::ConstIterator::pointer
+SectorRange::ConstIterator::operator->() const noexcept
+{
+   TDD_CHECK(
+      m_sector.number * spec::kSectorSize <= m_rangeEnd,
+      "Can't dereference end");
+
+   return &m_sector;
+}
+
+SectorRange::ConstIterator& SectorRange::ConstIterator::operator++() noexcept
+{
+   auto sectorAddr = m_sector.number * spec::kSectorSize;
+   TDD_CHECK(sectorAddr < m_rangeEnd, "Can't increment past end");
+
+   ++m_sector.number;
+   sectorAddr += spec::kSectorSize;
+   if (sectorAddr >= m_rangeEnd) {
+      // we've reached the end;
+      m_sector.data = std::span<uint8_t>();
+      return *this;
+   }
+
+   const auto count = std::min(m_rangeEnd - sectorAddr, spec::kSectorSize);
+
+   m_sector.data = m_range.subspan(sectorAddr - m_rangeStart, count);
+
+   return *this;
+}
+
+SectorRange::ConstIterator SectorRange::ConstIterator::operator++(int) noexcept
+{
+   const auto tmp = *this;
+   this->operator++();
+   return tmp;
+}
+
+SectorRange::ConstIterator& SectorRange::ConstIterator::operator--() noexcept
+{
+   auto sectorAddr = m_sector.number * spec::kSectorSize;
+   TDD_CHECK(sectorAddr >= m_rangeStart, "Can't decrement past begin");
+
+   --m_sector.number;
+   sectorAddr -= spec::kSectorSize;
+   if (sectorAddr < m_rangeStart) {
+      const auto count = spec::kSectorSize + sectorAddr - m_rangeStart;
+      m_sector.data    = m_range.subspan(0, count);
+   }
+   else {
+      m_sector.data =
+         m_range.subspan(sectorAddr - m_rangeStart, spec::kSectorSize);
+   }
+
+   return *this;
+}
+
+SectorRange::ConstIterator SectorRange::ConstIterator::operator--(int) noexcept
+{
+   const auto tmp = *this;
+   this->operator--();
+   return tmp;
+}
+
+SectorRange::ConstIterator&
+SectorRange::ConstIterator::operator+=(const difference_type offset) noexcept
+{
+   if (offset == 0) {
+      return *this;
+   }
+   else if (offset < 0) {
+      return this->operator-=(-offset);
+   }
+
+   const auto targetSectorAddr =
+      (m_sector.number + offset - 1) * spec::kSectorSize;
+   TDD_CHECK(targetSectorAddr < m_rangeEnd, "Can't seek after end");
+
+   m_sector.number += offset - 1;
+   return this->operator++();
+}
+
+SectorRange::ConstIterator SectorRange::ConstIterator::operator+(
+   const difference_type offset) const noexcept
+{
+   auto tmp = *this;
+   tmp += offset;
+   return tmp;
+}
+
+SectorRange::ConstIterator&
+SectorRange::ConstIterator::operator-=(const difference_type offset) noexcept
+{
+   if (offset == 0) {
+      return *this;
+   }
+   else if (offset < 0) {
+      return this->operator+=(-offset);
+   }
+
+   const auto targetSectorAddr =
+      (m_sector.number - offset + 1) * spec::kSectorSize;
+   TDD_CHECK(targetSectorAddr > m_rangeStart, "Can't seek before begin");
+
+   m_sector.number -= offset - 1;
+   return this->operator--();
+}
+
+SectorRange::ConstIterator SectorRange::ConstIterator::operator-(
+   const difference_type offset) const noexcept
+{
+   auto tmp = *this;
+   tmp -= offset;
+   return tmp;
+}
+
+SectorRange::ConstIterator::difference_type
+SectorRange::ConstIterator::operator-(const ConstIterator& rhs) const noexcept
+{
+   CheckCompatible(rhs);
+   const int64_t start = m_sector.number;
+   const int64_t end   = rhs.m_sector.number;
+   return start - end;
+}
+
+SectorRange::ConstIterator::reference SectorRange::ConstIterator::operator[](
+   const difference_type offset) const noexcept
+{
+   return *(this->operator+(offset));
+}
+
+bool SectorRange::ConstIterator::operator==(
+   const ConstIterator& other) const noexcept
+{
+   CheckCompatible(other);
+   return m_sector.number == other.m_sector.number;
+}
+
+
+std::strong_ordering
+SectorRange::ConstIterator::operator<=>(const ConstIterator& rhs) const noexcept
+{
+   CheckCompatible(rhs);
+   return m_sector.number <=> rhs.m_sector.number;
+}
+
+SectorRange::ConstIterator::ConstIterator(
+   const uint64_t sectorNumber,
+   const uint64_t rangeAddr,
+   std::span<uint8_t> range) noexcept
+   : m_sector()
+   , m_rangeStart(rangeAddr)
+   , m_rangeEnd(rangeAddr + range.size_bytes())
+   , m_range(range)
+{
+   const auto startSector = StartSector(m_rangeStart);
+   const auto endSector   = EndSector(m_rangeEnd);
+
+   TDD_CHECK(
+      startSector <= sectorNumber && sectorNumber <= endSector,
+      "Sector out of range");
+
+   m_sector.number = sectorNumber;
+
+   if (m_sector.number == endSector) {
+      return;
+   }
+
+   ++m_sector.number;
+   this->operator--();
+}
+
+void SectorRange::ConstIterator::CheckCompatible(
+   const ConstIterator& other) const noexcept
+{
+   TDD_CHECK(
+      m_rangeStart == other.m_rangeStart,
+      "Range doesn't start from the same address");
+
+   TDD_CHECK(
+      m_rangeEnd == other.m_rangeEnd,
+      "Range doesn't end at the same address");
+
+   TDD_DCHECK(
+      0 == memcmp(m_range.data(), other.m_range.data(), m_range.size_bytes()),
+      "Different memory content");
+}
+
+SectorRange::Iterator::reference
+SectorRange::Iterator::operator*() const noexcept
+{
+   return *(this->operator->());
+}
+
+SectorRange::Iterator::pointer
+SectorRange::Iterator::operator->() const noexcept
+{
+   return const_cast<pointer>(Base::operator->());
+}
+
+SectorRange::Iterator& SectorRange::Iterator::operator++() noexcept
+{
+   Base::operator++();
+   return *this;
+}
+
+SectorRange::Iterator SectorRange::Iterator::operator++(int) noexcept
+{
+   auto tmp = *this;
+   Base::operator++();
+   return tmp;
+}
+
+SectorRange::Iterator& SectorRange::Iterator::operator--() noexcept
+{
+   Base::operator--();
+   return *this;
+}
+
+SectorRange::Iterator SectorRange::Iterator::operator--(int) noexcept
+{
+   auto tmp = *this;
+   Base::operator--();
+   return tmp;
+}
+
+SectorRange::Iterator&
+SectorRange::Iterator::operator+=(const difference_type offset) noexcept
+{
+   Base::operator+=(offset);
+   return *this;
+}
+
+SectorRange::Iterator
+SectorRange::Iterator::operator+(const difference_type offset) noexcept
+{
+   auto tmp = *this;
+   tmp += offset;
+   return tmp;
+}
+
+SectorRange::Iterator&
+SectorRange::Iterator::operator-=(const difference_type offset) noexcept
+{
+   Base::operator-=(offset);
+   return *this;
+}
+
+SectorRange::Iterator
+SectorRange::Iterator::operator-(const difference_type offset) noexcept
+{
+   auto tmp = *this;
+   tmp -= offset;
+   return tmp;
+}
+
+SectorRange::Iterator::reference
+SectorRange::Iterator::operator[](const difference_type offset) const noexcept
+{
+   return const_cast<reference>(Base::operator[](offset));
+}
+
+SectorRange::Iterator::Iterator(
+   const uint64_t sectorNumber,
+   const uint64_t rangeAddr,
+   std::span<uint8_t> range) noexcept
+   : Base(sectorNumber, rangeAddr, range)
+{}
+
+SectorRange::Iterator::Iterator(const ConstIterator& other)
+   : Base(other)
+{}
+
+SectorRange::SectorRange() noexcept
+   : m_addr(0)
+   , m_data()
+{}
+
+SectorRange::SectorRange(const uint64_t addr, std::span<uint8_t> data) noexcept
+   : m_addr(addr)
+   , m_data(data)
+{}
+
+SectorRange::iterator SectorRange::begin() noexcept
+{
+   return cbegin();
+}
+
+SectorRange::const_iterator SectorRange::begin() const noexcept
+{
+   return cbegin();
+}
+
+SectorRange::const_iterator SectorRange::cbegin() const noexcept
+{
+   return const_iterator(StartSector(m_addr), m_addr, m_data);
+}
+
+SectorRange::iterator SectorRange::end() noexcept
+{
+   return cend();
+}
+
+SectorRange::const_iterator SectorRange::end() const noexcept
+{
+   return cend();
+}
+
+SectorRange::const_iterator SectorRange::cend() const noexcept
+{
+   return const_iterator(
+      EndSector(m_addr + m_data.size_bytes()),
+      m_addr,
+      m_data);
+}
+
+bool SectorRange::empty() const noexcept
+{
+   return m_data.empty();
+}
+
+SectorRange::size_type SectorRange::size() const noexcept
+{
+   return EndSector(m_addr + m_data.size_bytes()) - StartSector(m_addr);
+}
+
+SectorRange::reference SectorRange::front() noexcept
+{
+   return *begin();
+}
+
+SectorRange::const_reference SectorRange::front() const noexcept
+{
+   return *begin();
+}
+
+SectorRange::reference SectorRange::back() noexcept
+{
+   auto last = end();
+   --last;
+   return *last;
+}
+
+SectorRange::const_reference SectorRange::back() const noexcept
+{
+   auto last = end();
+   --last;
+   return *last;
+}
+
+}

--- a/tk/ppftk/test/rom_patch/cd/sector_range_test.cpp
+++ b/tk/ppftk/test/rom_patch/cd/sector_range_test.cpp
@@ -1,0 +1,133 @@
+#include <ppftk/rom_patch/cd/sector_range.h>
+
+#include <ppftk/rom_patch/cd/spec.h>
+
+#include <doctest/doctest.h>
+
+#include <array>
+
+namespace tdd::tk::rompatch::cd {
+
+namespace {
+   static constexpr size_t kTestSectorCount = 12;
+   using TestSectors = std::array<spec::Sector, kTestSectorCount>;
+
+   TestSectors BuildTestSectors() noexcept
+   {
+      TestSectors sectors;
+      for (auto& s : sectors) {
+         std::copy(spec::kSync.begin(), spec::kSync.end(), s.sync);
+      }
+      return sectors;
+   }
+
+   static auto kTestSectors = BuildTestSectors();
+   static const std::span<uint8_t> kSectorData(
+      reinterpret_cast<uint8_t*>(kTestSectors.data()),
+      kTestSectorCount* spec::kSectorSize);
+
+   static constexpr uint64_t kTestSectorStart = 123 * spec::kSectorSize;
+
+   static constexpr uint64_t kSectorOffset = spec::kSectorSize / 2;
+
+   [[nodiscard]] size_t CountSectors(const SectorRange& range)
+   {
+      size_t count = 0;
+      for (const auto& s : range) {
+         ++count;
+         if (s.IsComplete()) {
+            const auto res = memcmp(
+               s.AsSector()->sync,
+               spec::kSync.data(),
+               spec::kSync.size());
+            CHECK(0 == res);
+         }
+      }
+      return count;
+   }
+}
+
+
+TEST_CASE("SectorRange: empty range")
+{
+   SectorRange range;
+   CHECK(0 == range.size());
+   CHECK(0 == std::distance(range.begin(), range.end()));
+}
+
+TEST_CASE("SectorRange: size")
+{
+   SUBCASE("Complete sectors")
+   {
+      SectorRange range(kTestSectorStart, kSectorData);
+      CHECK(kTestSectorCount == range.size());
+   }
+
+   SUBCASE("Partial first sector")
+   {
+      SectorRange range(
+         kTestSectorStart + kSectorOffset,
+         kSectorData.subspan(kSectorOffset));
+      CHECK(kTestSectorCount == range.size());
+   }
+
+   SUBCASE("Partial last sector")
+   {
+      SectorRange range(
+         kTestSectorStart,
+         kSectorData.subspan(
+            kSectorOffset,
+            kSectorData.size_bytes() - kSectorOffset));
+      CHECK(kTestSectorCount == range.size());
+   }
+
+   SUBCASE("Partial first and last sector")
+   {
+      // Instead of adjusting the start and end address, the whole range is
+      // simply shifted by kSectorOffset. This makes the data invalid sectors.
+      // But this test isn't using the data.
+      SectorRange range(kTestSectorStart + kSectorOffset, kSectorData);
+      CHECK(kTestSectorCount + 1 == range.size());
+   }
+}
+
+TEST_CASE("SectorRange: Iterate complete sectors")
+{
+   SectorRange range(kTestSectorStart, kSectorData);
+   CHECK(kTestSectorCount == std::distance(range.begin(), range.end()));
+   CHECK(kTestSectorCount == CountSectors(range));
+}
+
+TEST_CASE("SectorRange: Iterate sectors with partial first")
+{
+   SectorRange range(
+      kTestSectorStart + kSectorOffset,
+      kSectorData.subspan(kSectorOffset));
+   CHECK(kTestSectorCount == std::distance(range.begin(), range.end()));
+   CHECK(kTestSectorCount == CountSectors(range));
+}
+
+TEST_CASE("SectorRange: Iterate sectors with partial last")
+{
+   SectorRange range(
+      kTestSectorStart,
+      kSectorData.subspan(
+         0,
+         kSectorData.size_bytes() - kSectorOffset));
+   CHECK(kTestSectorCount == std::distance(range.begin(), range.end()));
+   CHECK(kTestSectorCount == CountSectors(range));
+}
+
+TEST_CASE("SectorRange: Iterate sectors with partial first and last")
+{
+   SectorRange range(
+      kTestSectorStart + kSectorOffset,
+      kSectorData.subspan(
+         kSectorOffset,
+         kSectorData.size_bytes() - spec::kSectorSize));
+
+   CHECK(kTestSectorCount == std::distance(range.begin(), range.end()));
+   CHECK(kTestSectorCount == CountSectors(range));
+}
+
+}


### PR DESCRIPTION
* Add SectorRange to view a block of memory as CD sectors.
* Remove nameless union warning in spec.h.
* Reformat spec.h.
* Add tests for SectorRange.