### PR TITLE
ppfinjector#37: Reimplement patch application

### DIFF
--- a/app/ppfinjector/src/ppfinjector.cpp
+++ b/app/ppfinjector/src/ppfinjector.cpp
@@ -193,7 +193,7 @@ namespace {
 
       // 3. Apply patch
       if (targetAddr.has_value()) {
-         g_patch->Patch(
+         std::ignore = g_patch->Patch(
             targetAddr.value(),
             std::span(static_cast<uint8_t*>(lpBuffer) , *lpNumberOfBytesRead));
       }

--- a/props/core.props
+++ b/props/core.props
@@ -8,6 +8,7 @@
   <PropertyGroup>
     <OutDir>$(TddBinDir)</OutDir>
     <IntDir>$(TddTempDir)</IntDir>
+    <CodeAnalysisRuleSet>CppCoreCheckRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Label="Configuration">
     <SpectreMitigation>Spectre</SpectreMitigation>

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/patcher.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/patcher.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <ppftk/rom_patch/ipatcher.h>
+
+#include <ppftk/rom_patch/cd/sector_patch.h>
+
+#include <ppfbase/preprocessor_utils.h>
+
+namespace tdd::tk::rompatch {
+class PatchDescriptor;
+}
+
+namespace tdd::tk::rompatch::cd {
+   class SectorView;
+
+   class [[nodiscard]] Patcher : public IPatcher
+   {
+   public:
+      Patcher(PatchDescriptor&& fullPatch);
+
+      TDD_DEFAULT_ALL_SPECIAL_MEMBERS(Patcher);
+
+      [[nodiscard]] std::optional<AdditionalReads> Patch(
+         const uint64_t addr,
+         std::span<uint8_t> buffer) override;
+
+   private:
+      AdditionalReads RequireAdditionalReads(
+         const uint64_t targetAddr,
+         std::span<uint8_t> buffer) const;
+
+      [[nodiscard]] bool RequireFullSector(
+         const SectorView& sector) const noexcept;
+
+      std::vector<SectorPatch> m_patches;
+   };
+}

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/sector_range.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/sector_range.h
@@ -70,6 +70,7 @@ public:
          std::span<uint8_t> range) noexcept;
 
       void CheckCompatible(const ConstIterator& other) const noexcept;
+      void LoadSector(uint64_t sectorAddr) noexcept;
 
       SectorView m_sector;
       uint64_t m_rangeStart;
@@ -140,12 +141,6 @@ public:
 
    [[nodiscard]] bool empty() const noexcept;
    [[nodiscard]] size_type size() const noexcept;
-
-   reference front() noexcept;
-   const_reference front() const noexcept;
-
-   reference back() noexcept;
-   const_reference back() const noexcept;
 
 private:
    uint64_t m_addr;

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/sector_view.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/sector_view.h
@@ -13,8 +13,8 @@ namespace spec {
 class [[nodiscard]] SectorView
 {
 public:
-   SectorView();
-   SectorView(const uint64_t addr, std::span<uint8_t> data);
+   SectorView() noexcept;
+   SectorView(const uint64_t addr, std::span<uint8_t> data) noexcept;
 
    ~SectorView() = default;
    TDD_DEFAULT_COPY_MOVE(SectorView);

--- a/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/flat_patch.h
@@ -87,7 +87,7 @@ namespace tdd::tk::rompatch {
       [[nodiscard]] bool empty() const noexcept;
 
       // IPatcher
-      void Patch(
+      std::optional<AdditionalReads> Patch(
          const uint64_t addr,
          std::span<uint8_t> buffer) override;
 

--- a/tk/ppftk/inc/ppftk/rom_patch/ipatcher.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ipatcher.h
@@ -1,14 +1,25 @@
 #pragma once
 
 #include <span>
+#include <optional>
 
 namespace tdd::tk::rompatch {
-   class [[nodiscard]] IPatcher
+
+class [[nodiscard]] IPatcher
+{
+public:
+   // Additional complete sectors to feed the patcher with before the whole
+   // range can be succesfully patched.
+   struct [[nodiscard]] AdditionalReads
    {
-   public:
-      virtual ~IPatcher() = default;
-      virtual void Patch(
-         const uint64_t addr,
-         std::span<uint8_t> buffer) = 0;
+      uint64_t firstAddr;
+      uint64_t lastAddr;
    };
+
+   virtual ~IPatcher() = default;
+   [[nodiscard]] virtual std::optional<AdditionalReads> Patch(
+      const uint64_t addr,
+      std::span<uint8_t> buffer) = 0;
+};
+
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patch_descriptor.h
@@ -53,6 +53,8 @@ namespace tdd::tk::rompatch {
       [[nodiscard]] const std::string& GetFileId() const noexcept;
       [[nodiscard]] const std::string& GetDescription() const noexcept;
 
+      [[nodiscard]] FullPatch&& TakeFullPatch() && noexcept;
+
    private:
       FullPatch m_fullPatch;
       ValidationData m_validationData;

--- a/tk/ppftk/inc/ppftk/rom_patch/patch_item.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patch_item.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <set>
 #include <vector>
 
 namespace tdd::tk::rompatch {

--- a/tk/ppftk/inc/ppftk/rom_patch/patchers.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/patchers.h
@@ -1,3 +1,4 @@
 #pragma once
 #include <ppftk/rom_patch/flat_patch.h>
 #include <ppftk/rom_patch/simple_patcher.h>
+#include <ppftk/rom_patch/cd/patcher.h>

--- a/tk/ppftk/inc/ppftk/rom_patch/simple_patcher.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/simple_patcher.h
@@ -10,11 +10,11 @@ namespace tdd::tk::rompatch {
    class [[nodiscard]] SimplePatcher : public IPatcher
    {
    public:
-      SimplePatcher(PatchDescriptor&& fullPatch);
+      SimplePatcher(PatchDescriptor&& fullPatch) noexcept;
 
       TDD_DEFAULT_ALL_SPECIAL_MEMBERS(SimplePatcher);
 
-      void Patch(
+      [[nodiscard]] std::optional<AdditionalReads> Patch(
          const uint64_t addr,
          std::span<uint8_t> buffer) override;
 
@@ -23,7 +23,7 @@ namespace tdd::tk::rompatch {
          const uint64_t tgtStart,
          const uint64_t tgtEnd) const noexcept;
 
-      PatchDescriptor m_patches;
+      PatchDescriptor::FullPatch m_patches;
       std::pair<uint64_t, uint64_t> m_addrRange;
 
    };

--- a/tk/ppftk/ppftk.vcxproj
+++ b/tk/ppftk/ppftk.vcxproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <ClInclude Include="inc\ppftk\config\app.h" />
     <ClInclude Include="inc\ppftk\config\patch.h" />
+    <ClInclude Include="inc\ppftk\rom_patch\cd\patcher.h" />
     <ClInclude Include="inc\ppftk\rom_patch\cd\sector_patch.h" />
     <ClInclude Include="inc\ppftk\rom_patch\cd\sector_range.h" />
     <ClInclude Include="inc\ppftk\rom_patch\cd\sector_view.h" />
@@ -35,6 +36,7 @@
     <ClCompile Include="src\config\app.cpp" />
     <ClCompile Include="src\config\app_impl.cpp" />
     <ClCompile Include="src\config\patch.cpp" />
+    <ClCompile Include="src\rom_patch\cd\patcher.cpp" />
     <ClCompile Include="src\rom_patch\cd\sector_patch.cpp" />
     <ClCompile Include="src\rom_patch\cd\sector_range.cpp" />
     <ClCompile Include="src\rom_patch\cd\sector_view.cpp" />

--- a/tk/ppftk/ppftk.vcxproj.filters
+++ b/tk/ppftk/ppftk.vcxproj.filters
@@ -77,8 +77,17 @@
     <ClInclude Include="inc\ppftk\rom_patch\patchers.h">
       <Filter>PublicHeaders\rom_patch</Filter>
     </ClInclude>
+    <ClInclude Include="inc\ppftk\rom_patch\cd\sector_patch.h">
+      <Filter>PublicHeaders\rom_patch\cd</Filter>
+    </ClInclude>
     <ClInclude Include="inc\ppftk\rom_patch\cd\spec.h">
       <Filter>PublicHeaders\rom_patch\cd</Filter>
+    </ClInclude>
+    <ClInclude Include="inc\ppftk\rom_patch\cd\patcher.h">
+      <Filter>PublicHeaders\rom_patch\cd</Filter>
+    </ClInclude>
+    <ClInclude Include="src\rom_patch\apply_patches.h">
+      <Filter>Source\rom_patch</Filter>
     </ClInclude>
     <ClInclude Include="inc\ppftk\rom_patch\cd\sector_range.h">
       <Filter>PublicHeaders\rom_patch\cd</Filter>
@@ -120,6 +129,12 @@
     </ClCompile>
     <ClCompile Include="src\rom_patch\simple_patcher.cpp">
       <Filter>Source\rom_patch</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rom_patch\cd\patcher.cpp">
+      <Filter>Source\rom_patch\cd</Filter>
+    </ClCompile>
+    <ClCompile Include="src\rom_patch\cd\sector_patch.cpp">
+      <Filter>Source\rom_patch\cd</Filter>
     </ClCompile>
     <ClCompile Include="src\rom_patch\cd\sector_range.cpp">
       <Filter>Source\rom_patch\cd</Filter>

--- a/tk/ppftk/ppftk_test.vcxproj
+++ b/tk/ppftk/ppftk_test.vcxproj
@@ -76,6 +76,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="test\ppftk_test.cpp" />
+    <ClCompile Include="test\rom_patch\cd\patcher_test.cpp" />
     <ClCompile Include="test\rom_patch\cd\sector_patch_test.cpp" />
     <ClCompile Include="test\rom_patch\cd\sector_range_test.cpp" />
   </ItemGroup>

--- a/tk/ppftk/ppftk_test.vcxproj.filters
+++ b/tk/ppftk/ppftk_test.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="test\rom_patch\cd\sector_patch_test.cpp">
       <Filter>Tests\rom_patch\cd</Filter>
     </ClCompile>
+    <ClCompile Include="test\rom_patch\cd\patcher_test.cpp">
+      <Filter>Tests\rom_patch\cd</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="test\rom_patch\cd\test_sector_data.h">

--- a/tk/ppftk/src/rom_patch/cd/patcher.cpp
+++ b/tk/ppftk/src/rom_patch/cd/patcher.cpp
@@ -1,0 +1,134 @@
+#include <ppftk/rom_patch/cd/patcher.h>
+
+#include <ppftk/rom_patch/patch_descriptor.h>
+#include <ppftk/rom_patch/cd/sector_range.h>
+#include <ppftk/rom_patch/cd/spec.h>
+
+#include <ppfbase/logging/logging.h>
+
+namespace tdd::tk::rompatch::cd {
+
+namespace {
+   std::vector<SectorPatch> Convert(PatchDescriptor::FullPatch&& patches)
+   {
+      std::vector<SectorPatch> sectorPatches(1);
+      for (auto&& p : patches) {
+         const auto res = sectorPatches.back().AddPatch(std::move(p));
+         if (SectorPatch::AddPatchResult::Added == res) {
+            continue;
+         }
+
+         sectorPatches.emplace_back(std::move(p));
+      }
+      return sectorPatches;
+   }
+
+   // Look for a patch with std::lower_bound. Finding the first one with a
+   // sector number that greater than or equal to the target SectorView.
+   [[nodiscard]] bool LowerBound(
+      const SectorPatch& patch,
+      const SectorView& sector)
+   {
+      return patch.SectorNumber() < sector.SectorNumber();
+   }
+
+   // Look for a patch with std::upper_bound. Finding the first one with a
+   // sector number that's greater than the target SectorView.
+   [[nodiscard]] bool UpperBound(
+      const SectorView& sector,
+      const SectorPatch& patch) noexcept
+   {
+      return sector.SectorNumber() < patch.SectorNumber();
+   }
+}
+
+Patcher::Patcher(PatchDescriptor&& fullPatch)
+   : m_patches(Convert(std::move(fullPatch).TakeFullPatch()))
+{}
+
+std::optional<IPatcher::AdditionalReads> Patcher::Patch(
+   const uint64_t addr,
+   std::span<uint8_t> buffer)
+{
+   {
+      const auto additionalReads = RequireAdditionalReads(addr, buffer);
+      if (additionalReads.firstAddr != 0 || additionalReads.lastAddr != 0) {
+         return additionalReads;
+      }
+   }
+
+   // Apply patches.
+
+   SectorRange range(addr, buffer);
+   auto firstSector = range.begin();
+   auto lastSector = range.end();
+   --lastSector;
+
+   auto firstPatch = std::lower_bound(
+      m_patches.begin(),
+      m_patches.end(),
+      *firstSector,
+      LowerBound);
+
+   auto lastPatch = std::upper_bound(
+      firstPatch,
+      m_patches.end(),
+      *lastSector,
+      UpperBound);
+
+   auto target = range.begin();
+   for (auto patch = firstPatch; patch < lastPatch; ++patch) {
+      target += patch->SectorNumber() - target->SectorNumber();
+      patch->Patch(*target);
+   }
+
+   return std::nullopt;
+}
+
+IPatcher::AdditionalReads Patcher::RequireAdditionalReads(
+   const uint64_t targetAddr,
+   std::span<uint8_t> buffer) const
+{
+   const SectorRange range(targetAddr, buffer);
+
+   AdditionalReads read{0};
+
+   if (range.empty()) {
+      TDD_DCHECK(false, "Patching empty range");
+      return read;
+   }
+
+   if (const auto& first = range.begin(); RequireFullSector(*first)) {
+      read.firstAddr = first->SectorAddress();
+   }
+
+   if (range.size() == 1) {
+      return read;
+   }
+
+   if (const auto& last = range.end() - 1; RequireFullSector(*last)) {
+      read.lastAddr= last->SectorAddress();
+   }
+
+   return read;
+}
+
+bool Patcher::RequireFullSector(const SectorView& sector) const noexcept
+{
+   if (sector.IsComplete()) {
+      return false;
+   }
+
+   auto patch = std::lower_bound(
+      m_patches.begin(),
+      m_patches.end(),
+      sector,
+      LowerBound);
+
+   if (patch->SectorNumber() == sector.SectorNumber()) {
+      return !patch->HasUpdatedEdc();
+   }
+   return false;
+}
+
+}

--- a/tk/ppftk/src/rom_patch/cd/sector_view.cpp
+++ b/tk/ppftk/src/rom_patch/cd/sector_view.cpp
@@ -6,13 +6,13 @@
 
 namespace tdd::tk::rompatch::cd {
 
-SectorView::SectorView()
+SectorView::SectorView() noexcept
    : m_number(0)
    , m_offset(0)
    , m_data()
 {}
 
-SectorView::SectorView(const uint64_t addr, std::span<uint8_t> data)
+SectorView::SectorView(const uint64_t addr, std::span<uint8_t> data) noexcept
    : m_number(addr / spec::kSectorSize)
    , m_offset(addr % spec::kSectorSize)
    , m_data(data)

--- a/tk/ppftk/src/rom_patch/flat_patch.cpp
+++ b/tk/ppftk/src/rom_patch/flat_patch.cpp
@@ -188,24 +188,24 @@ bool FlatPatch::empty() const noexcept
    return m_patch.empty();
 }
 
-void FlatPatch::Patch(
+std::optional<IPatcher::AdditionalReads> FlatPatch::Patch(
    const uint64_t addr,
    std::span<uint8_t> buffer)
 {
    const auto endAddr = addr + buffer.size_bytes();
 
    if (!IsInRange(addr, endAddr)) {
-      return;
+      return std::nullopt;
    }
 
    if (addr < m_lastRead->address) {
       if (!SeekBackward(addr, endAddr)) {
-         return;
+         return std::nullopt;
       }
    }
    else if (m_lastRead->address < addr) {
       if (!SeekForward(addr, endAddr)) {
-         return;
+         return std::nullopt;
       }
    }
 
@@ -240,6 +240,7 @@ void FlatPatch::Patch(
    }
 
    --m_lastRead;
+   return std::nullopt;
 }
 
 bool FlatPatch::IsInRange(

--- a/tk/ppftk/src/rom_patch/patch_descriptor.cpp
+++ b/tk/ppftk/src/rom_patch/patch_descriptor.cpp
@@ -263,4 +263,9 @@ const std::string& PatchDescriptor::GetDescription() const noexcept
    return m_description;
 }
 
+PatchDescriptor::FullPatch&& PatchDescriptor::TakeFullPatch() && noexcept
+{
+   return std::move(m_fullPatch);
+}
+
 }

--- a/tk/ppftk/test/rom_patch/cd/patcher_test.cpp
+++ b/tk/ppftk/test/rom_patch/cd/patcher_test.cpp
@@ -1,0 +1,75 @@
+#include <ppftk/rom_patch/cd/patcher.h>
+
+#include "test_sector_data.h"
+
+#include <ppftk/rom_patch/patch_descriptor.h>
+
+#include <doctest/doctest.h>
+
+namespace tdd::tk::rompatch::cd {
+
+namespace {
+   PatchDescriptor BuildPatches()
+   {
+      PatchDescriptor patches;
+      CHECK(patches.AddPatchData(
+         TestSector::kPatch.address,
+         TestSector::kPatch.data));
+      return patches;
+   }
+}
+
+TEST_CASE("Patcher: patch 1 complete sector")
+{
+   auto sectorData = TestSector::kOriginalSector;
+
+   Patcher patcher(BuildPatches());
+
+   CHECK(!patcher.Patch(TestSector::kSectorAddr, sectorData).has_value());
+
+   const auto sector = reinterpret_cast<spec::Sector*>(sectorData.data());
+   CHECK(
+      sector->xa.form1.edc.full ==
+      TestSector::kVerificationSector->xa.form1.edc.full);
+}
+
+TEST_CASE("Patcher: patching 1 partial sector")
+{
+   static constexpr size_t kOffset = 16;
+
+   auto sectorData = TestSector::kOriginalSector;
+   std::span<uint8_t> targetPortion(
+      sectorData.begin() + kOffset,
+      sectorData.end() - kOffset);
+
+   auto additionalRead = TestSector::kOriginalSector;
+
+   Patcher patcher(BuildPatches());
+
+   const auto additionalReads =
+      patcher.Patch(TestSector::kSectorAddr + kOffset, targetPortion);
+
+   CHECK(additionalReads.has_value());
+   CHECK(additionalReads->firstAddr == TestSector::kSectorAddr);
+   CHECK(additionalReads->lastAddr == 0);
+
+   // Nothing has been done to the target portion yet
+   CHECK(
+      0 ==
+      memcmp(
+         &TestSector::kOriginalSector[kOffset],
+         targetPortion.data(),
+         targetPortion.size_bytes()));
+
+   CHECK(!patcher.Patch(TestSector::kSectorAddr, additionalRead).has_value());
+
+   CHECK(!patcher.Patch(TestSector::kSectorAddr + kOffset, targetPortion)
+             .has_value());
+
+   const auto sector = reinterpret_cast<spec::Sector*>(sectorData.data());
+   CHECK(
+      sector->xa.form1.edc.full ==
+      TestSector::kVerificationSector->xa.form1.edc.full);
+}
+
+}

--- a/tk/ppftk/test/rom_patch/cd/sector_range_test.cpp
+++ b/tk/ppftk/test/rom_patch/cd/sector_range_test.cpp
@@ -123,8 +123,37 @@ TEST_CASE("SectorRange: Iterate sectors with partial first and last")
          kSectorOffset,
          kSectorData.size_bytes() - spec::kSectorSize));
 
-   CHECK(kTestSectorCount == std::distance(range.begin(), range.end()));
+   auto end = range.end();
+
+   CHECK(kTestSectorCount == std::distance(range.begin(), end));
    CHECK(kTestSectorCount == CountSectors(range));
+}
+
+TEST_CASE("SectorRange: Mid portion of a single sector")
+{
+   const SectorRange range(
+      kTestSectorStart + kSectorOffset,
+      kSectorData.subspan(kSectorOffset, 16));
+
+   const auto beg = range.begin();
+   auto end = range.end();
+   --end;
+   CHECK(beg == end);
+}
+
+TEST_CASE("SectorRange: 2 partial sectors")
+{
+   const SectorRange range(
+      kTestSectorStart + kSectorOffset,
+      kSectorData.subspan(kSectorOffset, spec::kSectorSize));
+   CHECK(range.size() == 2);
+
+   const auto beg = range.begin();
+   CHECK(beg->DataOffset() == kSectorOffset);
+   const auto last = beg + 1;
+   auto end = range.end();
+   --end;
+   CHECK(last == end);
 }
 
 }


### PR DESCRIPTION
```
* Turn CPP Core Guide static analysis rules.
* Make IPatcher::Patch return AdditionalReads if partial sectors can't be patched.

* Fix SectorRange.

* Add cd::Patcher for patching CD sectors.
* Add tests for cd::Patcher.
```