### PR TITLE
ppfinjector#35: Allow live_patch test to ignore EDC and ECC

### DIFF
--- a/app/emulauncher/src/cmds/test/live_patch.h
+++ b/app/emulauncher/src/cmds/test/live_patch.h
@@ -16,11 +16,13 @@ namespace tdd::app::emulauncher::cmd::test {
       bool Execute() override;
    private:
       void VerifyPaths();
-      void DoTest();
+      void DoTest() const;
 
       gsl::not_null<CLI::App*> m_cmd;
       std::filesystem::path m_original;
       std::filesystem::path m_verification;
+      bool m_checkEdc;
+      bool m_checkEcc;
    };
 
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/cd/spec.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/cd/spec.h
@@ -7,6 +7,11 @@ namespace tdd::tk::rompatch::cd::spec {
 // ECMA-130, 14
 inline constexpr size_t kSectorSize = 2352;
 
+inline constexpr size_t kEdcSize = 4;
+inline constexpr size_t kEccPSize = 172;
+inline constexpr size_t kEccQSize = 104;
+inline constexpr size_t kEccSize = kEccPSize + kEccQSize;
+
 // 14.1
 inline constexpr std::array<uint8_t, 12> kSync =
    {00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 00};
@@ -37,7 +42,7 @@ static_assert(sizeof(SectorHeader) == kSectorHeaderSize);
 union [[nodiscard]] Edc
 {
    uint32_t full;
-   uint8_t parts[4];
+   uint8_t parts[kEdcSize];
 };
 
 // 14
@@ -54,8 +59,8 @@ struct [[nodiscard]] Mode1Data
    
    // 8 bytes of '0'
    uint8_t intermediate[8];
-   uint8_t pParity[172];
-   uint8_t qParity[104];
+   uint8_t pParity[kEccPSize];
+   uint8_t qParity[kEccQSize];
 };
 
 // 14
@@ -98,8 +103,8 @@ struct [[nodiscard]] Mode2Xa1Data
 {
    uint8_t data[2048];
    Edc edc;
-   uint8_t pParity[172];
-   uint8_t qParity[104];
+   uint8_t pParity[kEccPSize];
+   uint8_t qParity[kEccQSize];
 };
 
 // CD-ROM XA: 4.6.1


### PR DESCRIPTION
* Add --check_edc and --check_ecc flags to live_patch test command.
* Add constants for ECC sizes to spec.h.