### PR TITLE
ppfinjector#24: Update EDC when patching CD image

### DIFF
--- a/app/emulauncher/src/cmds/test/live_patch.cpp
+++ b/app/emulauncher/src/cmds/test/live_patch.cpp
@@ -96,6 +96,8 @@ namespace {
       uint8_t mode = 0;
       uint8_t form = 0;
 
+      bool failForm2Edc = false;
+
       switch (target.header.parts.mode) {
       default:
          std::cout << "Unknown sector mode for sector " << sectorNumber << ": "
@@ -123,8 +125,10 @@ namespace {
          }
          else {
             form = 2;
-            blockSize =
-               cd::kSectorSize - (checkEdc ? 0 : cd::kEdcSize);
+            blockSize = cd::kSectorSize - cd::kEdcSize;
+            const auto tEdc = target.xa.form2.edc.full;
+            const auto vEdc = verification.xa.form2.edc.full;
+            failForm2Edc = tEdc != 0 && tEdc != vEdc;
          }
          break;
       }
@@ -132,6 +136,11 @@ namespace {
       if (0 != memcmp(&target, &verification, blockSize)) {
          throw std::runtime_error(
             "Sector " + std::to_string(sectorNumber) + " data mismatch");
+      }
+
+      if (failForm2Edc) {
+         throw std::runtime_error(
+            "Form 2 Sector " + std::to_string(sectorNumber) + " EDC mismatch");
       }
    }
 

--- a/base/ppfbase/inc/ppfbase/filesystem/file.h
+++ b/base/ppfbase/inc/ppfbase/filesystem/file.h
@@ -1,10 +1,26 @@
 #pragma once
 
+#include <ppfbase/stdext/type_traits.h>
+
 #include <optional>
+#include <system_error>
 
 #include <Windows.h>
 
 namespace tdd::base::fs::File {
 
-   [[nodiscard]] std::optional<int64_t> GetFilePointer(const HANDLE hFile);
+   namespace  details {
+      struct FilePointerTag{};
+   }
+
+   using FilePointer = stdext::strong_type<int64_t, details::FilePointerTag>;
+
+
+[[nodiscard]] std::optional<FilePointer> GetFilePointer(
+   const HANDLE hFile) noexcept;
+
+[[nodiscard]] std::error_code Seek(
+   const HANDLE hFile,
+   const FilePointer pos) noexcept;
+
 }

--- a/base/ppfbase/src/filesystem/file.cpp
+++ b/base/ppfbase/src/filesystem/file.cpp
@@ -2,27 +2,42 @@
 
 #include <ppfbase/filesystem/file.h>
 #include <ppfbase/logging/logging.h>
+#include <ppfbase/stdext/system_error.h>
 
 namespace tdd::base::fs::File {
 
-std::optional<int64_t> GetFilePointer(const HANDLE hFile)
-{
-   static constexpr LARGE_INTEGER kDontMoveFilePointer{ 0 };
+namespace {
+   LARGE_INTEGER ToLargeInt(const FilePointer pos) noexcept
+   {
+      return LARGE_INTEGER{.QuadPart = pos.get()};
+   }
+}
 
-   LARGE_INTEGER location{ 0 };
-   const auto success = SetFilePointerEx(
-      hFile,
-      kDontMoveFilePointer,
-      &location,
-      FILE_CURRENT);
+std::optional<FilePointer> GetFilePointer(const HANDLE hFile) noexcept
+{
+   static constexpr LARGE_INTEGER kDontMoveFilePointer{0};
+
+   LARGE_INTEGER location{0};
+   const auto success =
+      SetFilePointerEx(hFile, kDontMoveFilePointer, &location, FILE_CURRENT);
 
    if (success) {
-      return location.QuadPart;
+      return FilePointer(location.QuadPart);
    }
 
    const auto err = GetLastError();
    TDD_LOG_WARN() << "Unable to get current file pointer location: "
-      << std::error_code(err, std::system_category());
+                  << std::error_code(err, std::system_category());
    return std::nullopt;
 }
+
+std::error_code Seek(const HANDLE hFile, const FilePointer pos) noexcept
+{
+   if (::SetFilePointerEx(hFile, ToLargeInt(pos), nullptr, FILE_BEGIN)) {
+      return {};
+   }
+
+   return stdext::make_last_error();
+}
+
 }

--- a/tk/ppftk/inc/ppftk/rom_patch/ipatcher.h
+++ b/tk/ppftk/inc/ppftk/rom_patch/ipatcher.h
@@ -2,18 +2,22 @@
 
 #include <span>
 #include <optional>
+#include <vector>
 
 namespace tdd::tk::rompatch {
 
 class [[nodiscard]] IPatcher
 {
 public:
-   // Additional complete sectors to feed the patcher with before the whole
-   // range can be succesfully patched.
+   // Additional blocks of data to feed the patcher with before the whole
+   // range can be succesfully patched. For file format with fixed data blocks
+   // such as CDs, the range being patched could start or end in the middle of
+   // a block. It is expected that the Patcher would not request more than 2
+   // additional full blocks of data.
    struct [[nodiscard]] AdditionalReads
    {
-      uint64_t firstAddr;
-      uint64_t lastAddr;
+      std::vector<uint64_t> addrs;
+      uint64_t blockSize;
    };
 
    virtual ~IPatcher() = default;

--- a/tk/ppftk/test/rom_patch/cd/patcher_test.cpp
+++ b/tk/ppftk/test/rom_patch/cd/patcher_test.cpp
@@ -50,8 +50,8 @@ TEST_CASE("Patcher: patching 1 partial sector")
       patcher.Patch(TestSector::kSectorAddr.get() + kOffset, targetPortion);
 
    CHECK(additionalReads.has_value());
-   CHECK(additionalReads->firstAddr == TestSector::kSectorAddr.get());
-   CHECK(additionalReads->lastAddr == 0);
+   CHECK(additionalReads->addrs.front() == TestSector::kSectorAddr.get());
+   CHECK(additionalReads->addrs.size() == 1);
 
    // Nothing has been done to the target portion yet
    CHECK(


### PR DESCRIPTION
```
* Add Seek to base::fs::File.
* Fix BasicLog rotation when written from multiple sources.

* Make IPatcher::Patch return a list of addresses and a block size for the extra reads it requires.
* Handle extra read requests when the patcher asks for it.
* Use cd::Patcher when EDC calculation is required.

* Fix derefence end when checking for extra read.
* Accept 0 as good value for XA Form 2 EDC value.
* Fix CloseHandleHook not skipping nested hook calls.
```